### PR TITLE
Remove store failures in ledger seq test

### DIFF
--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,5 +1,4 @@
-{{ config(severity="warn"
-    , store_failures = true) }}
+{{ config(severity="warn") }}
 
 with
     ledger_sequence as (


### PR DESCRIPTION
DBT store failures creates and or deletes the failure table in `dbt_test__audit`. A problem occurs with file creation/deletion when there are multiple dbt models running in parallel.

Removing this test in favor of running dbt models more smoothly