### PR TITLE
Change config_setting_id and flags description docs

### DIFF
--- a/models/docs/sources/config_settings.md
+++ b/models/docs/sources/config_settings.md
@@ -10,22 +10,22 @@ These settings are set at the network level and requires a validator vote to upd
 {% docs config_setting_id %}
 Config setting id types
 
-| id | Type                                                         |
-|----|--------------------------------------------------------------|
-| 0  |ConfigSettingIdConfigSettingContractMaxSizeBytes              |
-| 1  |ConfigSettingIdConfigSettingContractComputeV0                 |
-| 2  |ConfigSettingIdConfigSettingContractLedgerCostV0              |
-| 3  |ConfigSettingIdConfigSettingContractHistoricalDataV0          |
-| 4  |ConfigSettingIdConfigSettingContractEventsV0                  |
-| 5  |ConfigSettingIdConfigSettingContractBandwidthV0               |
-| 6  |ConfigSettingIdConfigSettingContractCostParamsCpuInstructions |
-| 7  |ConfigSettingIdConfigSettingContractCostParamsMemoryBytes     |
-| 8  |ConfigSettingIdConfigSettingContractDataKeySizeBytes          |
-| 9  |ConfigSettingIdConfigSettingContractDataEntrySizeBytes        |
-| 10 |ConfigSettingIdConfigSettingStateTtl .                        |
-| 11 |ConfigSettingIdConfigSettingContractExecutionLanes            |
-| 12 |ConfigSettingIdConfigSettingBucketlistSizeWindow              |
-| 13 |ConfigSettingIdConfigSettingEvictionIterator                  |
+| id | Type|
+|-|-|
+| 0  |ConfigSettingIdConfigSettingContractMaxSizeBytes|
+| 1  |ConfigSettingIdConfigSettingContractComputeV0|
+| 2  |ConfigSettingIdConfigSettingContractLedgerCostV0|
+| 3  |ConfigSettingIdConfigSettingContractHistoricalDataV0|
+| 4  |ConfigSettingIdConfigSettingContractEventsV0|
+| 5  |ConfigSettingIdConfigSettingContractBandwidthV0|
+| 6  |ConfigSettingIdConfigSettingContractCostParamsCpuInstructions|
+| 7  |ConfigSettingIdConfigSettingContractCostParamsMemoryBytes|
+| 8  |ConfigSettingIdConfigSettingContractDataKeySizeBytes|
+| 9  |ConfigSettingIdConfigSettingContractDataEntrySizeBytes|
+| 10 |ConfigSettingIdConfigSettingStateTtl|
+| 11 |ConfigSettingIdConfigSettingContractExecutionLanes|
+| 12 |ConfigSettingIdConfigSettingBucketlistSizeWindow|
+| 13 |ConfigSettingIdConfigSettingEvictionIterator|
 {% enddocs %}
 
 {% docs contract_max_size_bytes %}

--- a/models/docs/sources/state_tables.md
+++ b/models/docs/sources/state_tables.md
@@ -18,7 +18,26 @@ The sum of all sell offers owned by this account for XLM only
 The `accounts` table only reports monetary balances for XLM. Any other asset class is reported in the `trust_lines` table.
 {% enddocs %}
 
-{% docs flags %}
+{% docs flags_trust_lines %}
+Denotes the enabling and disabling of certain asset issuer privileges.
+
+- Required Field
+
+#### Notes:
+Flags are set on the issuer accounts for an asset. When user accounts trust an asset, the flags applied to the asset originate from this account. Depending on the state table, flags can have various meanings.
+
+#### `trust_lines`:
+
+| Flag    | Meaning                      |
+|---------|------------------------------|
+| 0       | None, Default                      |
+| 1       | Authorized (issuer has authorized account to perform transaction with its credit)        |
+| 2       | Authorized to Maintain Liabilities (issuer has authorized account to maintain and reduce liabilities for its credit)        |
+| 4       | Clawback Enabled (issuer has specified that it may clawback its credit, including claimable balances)     |
+
+{% enddocs %}
+
+{% docs flags_accounts_balances %}
 Denotes the enabling and disabling of certain asset issuer privileges.
 
 - Required Field
@@ -36,22 +55,22 @@ Flags are set on the issuer accounts for an asset. When user accounts trust an a
 | 4        | Auth Immutable (all auth flags are read only when set)         |
 | 8        | Auth Clawback Enabled (asset can be clawed back from the user) |
 
+{% enddocs %}
+
+{% docs flags_offers %}
+Denotes the enabling and disabling of certain asset issuer privileges.
+
+- Required Field
+
+#### Notes:
+Flags are set on the issuer accounts for an asset. When user accounts trust an asset, the flags applied to the asset originate from this account. Depending on the state table, flags can have various meanings.
+
 #### `offers`:
 
 | Flag    | Meaning                      |
 |---------|------------------------------|
 | 0       | Default                      |
 | 1       | Passive (offer with this flag will not act on and take a reverse offer of equal price)        |
-
-#### `trust_lines`:
-Flags are set on the issuer accounts for an asset. When user accounts trust an asset, the flags applied to the asset originate from this account.
-
-| Flag    | Meaning                      |
-|---------|------------------------------|
-| 0       | None, Default                      |
-| 1       | Authorized (issuer has authorized account to perform transaction with its credit)        |
-| 2       | Authorized to Maintain Liabilities (issuer has authorized account to maintain and reduce liabilities for its credit)        |
-| 4       | Clawback Enabled (issuer has specified that it may clawback its credit, including claimable balances)     |
 
 {% enddocs %}
 

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -89,7 +89,7 @@ models:
                 where: closed_at > current_timestamp - interval 2 day
 
       - name: flags
-        description: '{{ doc("flags") }}'
+        description: '{{ doc("flags_accounts_balances") }}'
         tests:
           - not_null:
               config:

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -129,7 +129,7 @@ models:
                 where: closed_at > current_timestamp - interval 2 day
 
       - name: flags
-        description: '{{ doc("flags") }}'
+        description: '{{ doc("flags_offers") }}'
         tests:
           - not_null:
               config:

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -95,7 +95,7 @@ models:
                 where: closed_at > current_timestamp - interval 2 day
       
       - name: flags
-        description: '{{ doc("flags") }}'
+        description: '{{ doc("flags_trust_lines") }}'
         tests:
           - not_null:
               config:

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -79,7 +79,7 @@ sources:
                     where: batch_run_date > current_datetime - interval 2 day
 
           - name: flags
-            description: '{{ doc("flags") }}'
+            description: '{{ doc("flags_accounts_balances") }}'
             tests:
               - not_null:
                   config:

--- a/models/sources/src_claimable_balance.yml
+++ b/models/sources/src_claimable_balance.yml
@@ -92,7 +92,7 @@ sources:
                     where: batch_run_date > current_datetime - interval 2 day
 
           - name: flags
-            description: '{{ doc("flags") }}'
+            description: '{{ doc("flags_accounts_balances") }}'
             tests:
               - not_null:
                   config:

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -89,7 +89,7 @@ sources:
                     where: batch_run_date > current_datetime - interval 2 day
 
           - name: flags
-            description: '{{ doc("flags") }}'
+            description: '{{ doc("flags_offers") }}'
             tests:
               - not_null:
                   config:

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -102,7 +102,7 @@ sources:
                     where: batch_run_date > current_datetime - interval 2 day
 
           - name: flags
-            description: '{{ doc("flags") }}'
+            description: '{{ doc("flags_trust_lines") }}'
             tests:
               - not_null:
                   config:


### PR DESCRIPTION
The character limit from Bigquery field descriptions is 1024 characters.

This PR decreases the `config_setting_id` field and divides the `flag` field into 3 new fields to fit this limit.

New fields:
- `flags_trust_lines`
- `flags_accounts_balances`
- `flags_offers`