### PR TITLE
Update `dbtutils` tests

### DIFF
--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
                 severity: warn

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/fee_stats_agg.yml
+++ b/models/marts/fee_stats_agg.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: day
-          field: day_agg
+          field: cast(day_agg as timestamp)
           interval: 2
           config:
                 severity: warn

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: day
-          field: batch_run_date
+          field: cast(batch_run_date as timestamp)
           interval: 2
           config:
                 severity: warn

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: hour
-          field: cast(closed_at as datetime)
+          field: closed_at
           interval: 12
           config:
             severity: warn

--- a/models/marts/trade_agg.yml
+++ b/models/marts/trade_agg.yml
@@ -6,7 +6,7 @@ models:
     tests:
       - dbt_utils.recency:
           datepart: day
-          field: day_agg
+          field: cast(day_agg as timestamp)
           interval: 2
           config:
                 severity: warn

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_claimable_balance.yml
+++ b/models/sources/src_claimable_balance.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(closed_at as datetime)
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -7,15 +7,6 @@ sources:
       - name: config_settings
         description: '{{ doc("config_settings") }}'
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - config_setting_id

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(closed_at as datetime)
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -8,9 +8,9 @@ sources:
         description: '{{ doc("contract_code") }}'
         tests:
           - dbt_utils.recency:
-              datepart: hour
+              datepart: day
               field: closed_at
-              interval: 12
+              interval: 3
               config:
                 severity: warn
               meta:

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(closed_at as datetime)
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: cast(batch_run_date as timestamp)
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(closed_at as datetime)
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(ledger_closed_at as datetime)
+              field: ledger_closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: batch_run_date
+              field: closed_at
               interval: 12
               config:
                 severity: warn

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -9,7 +9,7 @@ sources:
         tests:
           - dbt_utils.recency:
               datepart: hour
-              field: cast(closed_at as datetime)
+              field: closed_at
               interval: 12
               config:
                 severity: warn


### PR DESCRIPTION
The `dbtutils` library introduced breaking changes during the major version upgrade from `0.9.5` to `1.1.1`.

The `recency` test changed the expected data type from `DATETIME` to `TIMESTAMP`. This PR updates all dbtutils recency tests to reflect this change.

Updating these tests to `closed_at`, which is not the partition field on some tables, does not impact query performance or cost because these tests aggregate the field referenced: 

```
select max(<timestamp>)
from `crypto-stellar.crypto_stellar.<table>`
..
..
..
```

In most cases, this query processes ~5GB or less, even for very large tables, like `trust_lines`.