### PR TITLE
Dbt docs website CI

### DIFF
--- a/.github/workflows/dbt-docs-website.yml
+++ b/.github/workflows/dbt-docs-website.yml
@@ -1,0 +1,48 @@
+name: DBT Docs Generate and Upload to GCS
+
+on:
+    push:
+        branches:
+            - dbt-docs-website
+
+env:
+    DBT_DEFAULT_PROFILE_TARGET: stellar_dbt_public
+    DBT_PROFILES_DIR: ${{ github.workspace }}
+    DBT_MAX_BYTES_BILLED: 1000000000000
+    DBT_JOB_TIMEOUT: 300
+    DBT_THREADS: 1
+    DBT_JOB_RETRIES: 1
+
+jobs:
+    dbt-docs:
+        runs-on: ubuntu-latest
+
+        steps:
+        - name: Set up Python
+          uses: actions/setup-python@v2
+          with:
+            python-version: 3.8
+
+        - name: Checkout Repository
+          uses: actions/checkout@v2
+
+        - id: 'auth'
+          uses: 'google-github-actions/auth@v2'
+          with:
+            credentials_json: "${{ secrets.CREDS_PROD_HUBBLE }}"
+
+        - name: Install dependencies
+          run: pip install -r requirements.txt
+
+        - name: Generate dbt docs
+          run: |
+            dbt deps
+            dbt docs generate
+
+        - id: 'upload-folder'
+          uses: 'google-github-actions/upload-cloud-storage@v2'
+          with:
+            path: '${{ github.workspace }}/target'
+            destination: 'www.stellar-dbt-docs.com'
+            parent: false
+            glob: '*.json|*.html'

--- a/.github/workflows/dbt-docs-website.yml
+++ b/.github/workflows/dbt-docs-website.yml
@@ -42,6 +42,7 @@ jobs:
         - id: 'upload-folder'
           uses: 'google-github-actions/upload-cloud-storage@v2'
           with:
+            process_gcloudignore: false
             path: '${{ github.workspace }}/target'
             destination: 'www.stellar-dbt-docs.com'
             parent: false

--- a/.github/workflows/dbt-docs-website.yml
+++ b/.github/workflows/dbt-docs-website.yml
@@ -3,7 +3,7 @@ name: DBT Docs Generate and Upload to GCS
 on:
     push:
         branches:
-            - dbt-docs-website
+            - master
 
 env:
     DBT_DEFAULT_PROFILE_TARGET: stellar_dbt_public

--- a/.github/workflows/dbt-docs-website.yml
+++ b/.github/workflows/dbt-docs-website.yml
@@ -29,6 +29,7 @@ jobs:
         - id: 'auth'
           uses: 'google-github-actions/auth@v2'
           with:
+            project_id: 'hubble-261722'
             credentials_json: "${{ secrets.CREDS_PROD_HUBBLE }}"
 
         - name: Install dependencies

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -80,7 +80,7 @@ project_dir = ./
 # If your project works only with .env files you need to:
 ### Change ~/.dbt/ for ./ on profiles_dir variable here
 ### Remove steps on the pipeline that create and copy the profiles.yml to ~/.dbt/ folder.
-profiles_dir = ./
+profiles_dir = ~/.dbt/
 # Name of the profiles.
 # CHANGE THIS TO THE PROFILE NAME ON YOUR PROFILES.YML FILE
 profile = stellar_dbt_public


### PR DESCRIPTION
Whenever there are new updates in stellar-dbt-public, a new dbt docs is generated and passed to the bucket where dbt docs public website is located (inside Hubble project).

* dbt_profile_dir changed to ~/.dbt to help development environment.