### PR TITLE
Add account_creation_date and min_sequence_number

### DIFF
--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -59,7 +59,7 @@ with
                 > (select max(t.upstream_insert_ts) from {{ this }} as t)
         {% endif %}
     )
-    
+
     , account_date as (
         select
             account_id

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -59,10 +59,31 @@ with
                 > (select max(t.upstream_insert_ts) from {{ this }} as t)
         {% endif %}
     )
+    
+    , account_date as (
+        select
+            account_id
+            , min(batch_run_date) as account_creation_date
+            , min(sequence_number) as min_sequence_number
+        from {{ ref('stg_accounts') }}
+        group by account_id
+    )
+
+    , get_creation_account as (
+        select
+            current_accts.*
+            , account_date.account_creation_date
+            , account_date.min_sequence_number
+        from current_accts
+        left join account_date
+            on current_accts.account_id = account_date.account_id
+    )
 
 /* Return the same fields as the `accounts` table */
 select
     account_id
+    , account_creation_date
+    , min_sequence_number
     , balance
     , buying_liabilities
     , selling_liabilities
@@ -87,5 +108,5 @@ select
     , batch_run_date
     , batch_insert_ts as upstream_insert_ts
     , current_timestamp() as batch_insert_ts
-from current_accts
+from get_creation_account
 where row_nr = 1

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -75,7 +75,7 @@ with
             , account_date.account_creation_date
             , account_date.min_sequence_number
         from current_accts
-        left join account_date
+        join account_date
             on current_accts.account_id = account_date.account_id
         where current_accts.row_nr = 1
     )

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -39,13 +39,13 @@ with
             , a.batch_run_date
             , a.batch_insert_ts
             , row_number()
-            over (
-                partition by a.account_id
-                order by
-                    a.last_modified_ledger desc
-                    , a.ledger_entry_change desc
-            )
-            as row_nr
+                over (
+                    partition by a.account_id
+                    order by
+                        a.last_modified_ledger desc
+                        , a.ledger_entry_change desc
+                )
+                as row_nr
         from {{ ref('stg_accounts') }} as a
         join {{ ref('stg_history_ledgers') }} as l
             on a.last_modified_ledger = l.sequence

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -77,6 +77,7 @@ with
         from current_accts
         left join account_date
             on current_accts.account_id = account_date.account_id
+        where current_accts.row_nr = 1
     )
 
 /* Return the same fields as the `accounts` table */
@@ -109,4 +110,3 @@ select
     , batch_insert_ts as upstream_insert_ts
     , current_timestamp() as batch_insert_ts
 from get_creation_account
-where row_nr = 1


### PR DESCRIPTION
Added account_creation_date and min_sequence_number to accounts_current table to fix the problem with modeling shown in dbt project evaluator.