### PR TITLE
SCD staging tables dedup function added

### DIFF
--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -28,6 +28,11 @@ with
             , closed_at
             , ledger_sequence
         from raw_table
+        qualify
+            row_number() over (
+                partition by balance_id, ledger_entry_change
+                order by closed_at desc
+            ) = 1
     )
 
 select *

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -35,6 +35,11 @@ with
             , closed_at
             , ledger_sequence
         from raw_table
+        qualify
+            row_number() over (
+                partition by liquidity_pool_id, ledger_entry_change, last_modified_ledger
+                order by closed_at desc
+            ) = 1
     )
 
 select *


### PR DESCRIPTION
## Overview
_We have identified issues with the intermediate scd_claimable_balances and scd_liquidity_pools models creation and testing due to duplicate data coming from the sources. To temporarily mitigate the problem while it is being investigated and a permanent solution is proposed, we have implemented a dedup function in the staging models that this tables pull from. This is to prevent downstream model creation and testing failures stemming from this issue._

## Key changes
-  _row_number window function and qualify function added to stg_claimable_balances and stg_liquidity_pools to remove duplicated data to downstream models._

## Other notes

## Related links
- _[dbt model alert | Model: scd_src_claimable_balances | Status: error](https://indicium-external.slack.com/archives/C06KR1UB6TG/p1716830021799149)_

## Checklist
_The following items are not covered by automated testing._
- [N/A] All added/modified models and columns are documented and tested in `schema.yml` files.
- [X] All tests pass. **OR**    
    _Check one:_
    - [ ] There are no new test failures, whether or not the existing model was intentionally changed for this PR.
    - [ ] This PR causes new test failures and there is a plan in place for addressing them.