### PR TITLE
release CI template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,5 @@
+template: |
+  ## What's Changed
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION


### PR DESCRIPTION
### What

Template necessary to be in master before being able to to do the release CI.

### Why

Without the template in master, we are unable to see the CI release working before publishing it.

### Known limitations

[N/A]
