### PR TITLE
dbt source freshness applied to public sources

### DIFF
--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: accounts
         description: '{{ doc("accounts") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - account_id

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: account_signers
         description: '{{ doc("accounts_signers") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - account_id

--- a/models/sources/src_claimable_balance.yml
+++ b/models/sources/src_claimable_balance.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: claimable_balances
         description: '{{ doc("claimable_balances") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - balance_id

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -6,6 +6,10 @@ sources:
     tables:
       - name: config_settings
         description: '{{ doc("config_settings") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -7,15 +7,6 @@ sources:
       - name: contract_code
         description: '{{ doc("contract_code") }}'
         tests:
-          - dbt_utils.recency:
-              datepart: day
-              field: closed_at
-              interval: 3
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - contract_code_hash

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -7,15 +7,6 @@ sources:
       - name: contract_data
         description: '{{ doc("contract_data") }}'
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: contract_id
             description: '{{ doc("contract_id") }}'

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_assets_staging
         description: '{{ doc("history_assets_staging") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: batch_run_date
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: cast(batch_run_date as timestamp)
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: asset_id
             description: '{{ doc("asset_id") }}'

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_effects
         description: '{{ doc("history_effects") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: address
             description: '{{ doc("address") }}'

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_ledgers
         description: '{{ doc("history_ledgers") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: sequence
             description: '{{ doc("sequence") }}'

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_operations
         description: '{{ doc("history_operations") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: id
             description: '{{ doc("operation_id") }}'

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_trades
         description: '{{ doc("history_trades") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: batch_run_date
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: ledger_closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - history_operation_id

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: history_transactions
         description: '{{ doc("history_transactions") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
         columns:
           - name: id
             description: '{{ doc("transaction_id") }}'

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: liquidity_pools
         description: '{{ doc("liquidity_pools") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - liquidity_pool_id

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: offers
         description: '{{ doc("liquidity_pools") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - offer_id

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: trust_lines
         description: '{{ doc("trust_lines") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - account_id

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -6,16 +6,11 @@ sources:
     tables:
       - name: ttl
         description: '{{ doc("ttl") }}'
+        freshness:
+          warn_after: {count: 30, period: minute}
+          error_after: {count: 60, period: minute}
+        loaded_at_field: closed_at
         tests:
-          - dbt_utils.recency:
-              datepart: hour
-              field: closed_at
-              interval: 12
-              config:
-                severity: warn
-              meta:
-                description:
-                  "Monitors the freshness of your table over time, as the expected time between data updates."
           - dbt_utils.unique_combination_of_columns:
               combination_of_columns:
                 - key_hash


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>
  
### PR Structure

* [X] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [X] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
* [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

* [X] I've decided if this PR requires a new major/minor/patch version accordingly to
  [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* . 
</details>

### What

This PR brings a new proposal for testing sources using the native dbt test `dbt source freshness`, along with intervals defined according to the build execution (dbt_enriched_base_tables DAG) interval of these models/sources. Thus, data with a severity of 'warn' will be considered outdated if it is more than 30 minutes old, and 'error' for intervals exceeding 2x the interval, meaning a difference greater than 60 minutes.

### Why

Source testing is necessary in the pipeline to identify if the data is not outdated and prevent models from being built based on such data, ensuring greater quality and reliability.

### Known limitations

The suggested interval should be discussed to verify if it is more appropriate and fits the expected intervals according to Stellar data pipeline, in order to properly and more accurately assess whether the data is outdated or not.