### PR TITLE
Reduce field length to fit in BQ

### DIFF
--- a/models/docs/sources/config_settings.md
+++ b/models/docs/sources/config_settings.md
@@ -10,22 +10,22 @@ These settings are set at the network level and requires a validator vote to upd
 {% docs config_setting_id %}
 Config setting id types
 
-| id  | Type                                                          |
-| --- | ------------------------------------------------------------- |
-| 0   | ConfigSettingIdConfigSettingContractMaxSizeBytes              |
-| 1   | ConfigSettingIdConfigSettingContractComputeV0                 |
-| 2   | ConfigSettingIdConfigSettingContractLedgerCostV0              |
-| 3   | ConfigSettingIdConfigSettingContractHistoricalDataV0          |
-| 4   | ConfigSettingIdConfigSettingContractEventsV0                  |
-| 5   | ConfigSettingIdConfigSettingContractBandwidthV0               |
-| 6   | ConfigSettingIdConfigSettingContractCostParamsCpuInstructions |
-| 7   | ConfigSettingIdConfigSettingContractCostParamsMemoryBytes     |
-| 8   | ConfigSettingIdConfigSettingContractDataKeySizeBytes          |
-| 9   | ConfigSettingIdConfigSettingContractDataEntrySizeBytes        |
-| 10  | ConfigSettingIdConfigSettingStateTtl                          |
-| 11  | ConfigSettingIdConfigSettingContractExecutionLanes            |
-| 12  | ConfigSettingIdConfigSettingBucketlistSizeWindow              |
-| 13  | ConfigSettingIdConfigSettingEvictionIterator                  |
+| id | Type|
+|-|-|
+| 0  |ConfigSettingIdConfigSettingContractMaxSizeBytes|
+| 1  |ConfigSettingIdConfigSettingContractComputeV0|
+| 2  |ConfigSettingIdConfigSettingContractLedgerCostV0|
+| 3  |ConfigSettingIdConfigSettingContractHistoricalDataV0|
+| 4  |ConfigSettingIdConfigSettingContractEventsV0|
+| 5  |ConfigSettingIdConfigSettingContractBandwidthV0|
+| 6  |ConfigSettingIdConfigSettingContractCostParamsCpuInstructions|
+| 7  |ConfigSettingIdConfigSettingContractCostParamsMemoryBytes|
+| 8  |ConfigSettingIdConfigSettingContractDataKeySizeBytes|
+| 9  |ConfigSettingIdConfigSettingContractDataEntrySizeBytes|
+| 10 |ConfigSettingIdConfigSettingStateTtl|
+| 11 |ConfigSettingIdConfigSettingContractExecutionLanes|
+| 12 |ConfigSettingIdConfigSettingBucketlistSizeWindow|
+| 13 |ConfigSettingIdConfigSettingEvictionIterator|
 
 {% enddocs %}
 

--- a/models/docs/sources/state_tables.md
+++ b/models/docs/sources/state_tables.md
@@ -31,12 +31,12 @@ Flags are set on the issuer accounts for an asset. When user accounts trust an a
 
 #### `trust_lines`:
 
-| Flag | Meaning                                                                                                              |
-| ---- | -------------------------------------------------------------------------------------------------------------------- |
-| 0    | None, Default                                                                                                        |
-| 1    | Authorized (issuer has authorized account to perform transaction with its credit)                                    |
-| 2    | Authorized to Maintain Liabilities (issuer has authorized account to maintain and reduce liabilities for its credit) |
-| 4    | Clawback Enabled (issuer has specified that it may clawback its credit, including claimable balances)                |
+| Flag    | Meaning                      |
+|---------|------------------------------|
+| 0       | None, Default                      |
+| 1       | Authorized (issuer has authorized account to perform transaction with its credit)        |
+| 2       | Authorized to Maintain Liabilities (issuer has authorized account to maintain and reduce liabilities for its credit)        |
+| 4       | Clawback Enabled (issuer has specified that it may clawback its credit, including claimable balances)     |
 
 {% enddocs %}
 
@@ -51,13 +51,13 @@ Flags are set on the issuer accounts for an asset. When user accounts trust an a
 
 #### `accounts` and `claimable_balances`:
 
-| Flag | Meaning                                                                                      |
-| ---- | -------------------------------------------------------------------------------------------- |
-| 0    | None - Default                                                                               |
-| 1    | Auth Required (all trustlines by default are untrusted and require manual trust established) |
-| 2    | Auth Revocable (allows trustlines to be revoked if account no longer trusts asset)           |
-| 4    | Auth Immutable (all auth flags are read only when set)                                       |
-| 8    | Auth Clawback Enabled (asset can be clawed back from the user)                               |
+| Flag    | Meaning                |
+|----------|----------------------------|
+| 0        | None - Default             |
+| 1        | Auth Required (all trustlines by default are untrusted and require manual trust established)            |
+| 2        | Auth Revocable (allows trustlines to be revoked if account no longer trusts asset) |
+| 4        | Auth Immutable (all auth flags are read only when set)         |
+| 8        | Auth Clawback Enabled (asset can be clawed back from the user) |
 
 {% enddocs %}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

The current dbt build is broken and cannot release or build a new docker image because field descriptions violate BigQuery field description limitations:

```
[0m18:30:39  [33m400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/test-hubble-319619/datasets/dbt_jenkins_crypto_stellar_dbt/tables/config_settings_current?prettyPrint=false: The description for field config_setting_id is too long. The maximum length is 1024 characters.[0m
[0m18:30:39  
[0m18:30:39  [33m400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/test-hubble-319619/datasets/dbt_jenkins_crypto_stellar_dbt/tables/accounts_current?prettyPrint=false: The description for field flags is too long. The maximum length is 1024 characters.[0m
[0m18:30:39  
[0m18:30:39  [33m400 PATCH https://bigquery.googleapis.com/bigquery/v2/projects/test-hubble-319619/datasets/dbt_jenkins_crypto_stellar_dbt/tables/trust_lines_current?prettyPrint=false: The description for field flags is too long. The maximum length is 1024 characters.[0m
```

This PR resolves the violations by shortening the markdown used to generate tables. The change is visually ugly, but gets the fields under the 1024 character limit.

### Why

The stellar-dbt repo persists docs to BigQuery and pushes any updates through this configuration: https://github.com/stellar/stellar-dbt/blob/master/dbt_project.yml#L68 The pipeline is broken because dbt is unable to persist the docs.

### Known limitations

[TODO or N/A]
