### PR TITLE
Updates to use closed_at instead of batch_run_date

### DIFF
--- a/models/marts/ledger_current_state/claimable_balances_current.sql
+++ b/models/marts/ledger_current_state/claimable_balances_current.sql
@@ -2,7 +2,8 @@
     config(
         tags = ["current_state"],
         materialized = "incremental",
-        unique_key = "balance_id"
+        unique_key = "balance_id",
+        cluster_by = "balance_id"
     )
 }}
 /* Returns the latest state of each claimable balance in the `claimable_balances` table.
@@ -37,7 +38,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cb.batch_run_date >= date_sub(current_date(), interval 2 day)
+                cb.closed_at >= timestamp_sub(current_timestamp(), interval 2 day)
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -18,7 +18,7 @@ models:
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: claimants
         description: '{{ doc("claimants") }}'
@@ -28,7 +28,7 @@ models:
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: asset_code
         description: '{{ doc("asset_code") }}'
@@ -36,7 +36,7 @@ models:
           - not_null:
               config:
                 where: asset_type != 'native'
-                  and batch_run_date > current_datetime - interval 2 day
+                  and closed_at > current_timestamp - interval 2 day
 
       - name: asset_issuer
         description: '{{ doc("asset_issuer") }}'
@@ -44,42 +44,42 @@ models:
           - not_null:
               config:
                 where: asset_type != 'native'
-                  and batch_run_date > current_datetime - interval 2 day
+                  and closed_at > current_timestamp - interval 2 day
 
       - name: asset_amount
         description: '{{ doc("asset_amount") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: sponsor
         description: '{{ doc("sponsor") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: flags
         description: '{{ doc("flags_accounts_balances") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: last_modified_ledger
         description: '{{ doc("last_modified_ledger") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: ledger_entry_change
         description: '{{ doc("ledger_entry_change") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
           - accepted_values:
               values: [0, 1, 2]
               quote: false
@@ -89,46 +89,46 @@ models:
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: batch_id
         description: '{{ doc("batch_id") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: batch_run_date
         description: '{{ doc("batch_run_date") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: closed_at
         description: '{{ doc("closed_at") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: ledger_sequence
         description: '{{ doc("ledger_sequence") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: upstream_insert_ts
         description: '{{ doc("upstream_insert_ts") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day
 
       - name: batch_insert_ts
         description: '{{ doc("batch_insert_ts") }}'
         tests:
           - not_null:
               config:
-                where: batch_run_date > current_datetime - interval 2 day
+                where: closed_at > current_timestamp - interval 2 day

--- a/models/marts/ledger_current_state/config_settings_current.sql
+++ b/models/marts/ledger_current_state/config_settings_current.sql
@@ -72,10 +72,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cfg.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cfg.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                cfg.closed_at >= timestamp_sub(current_timestamp(), interval 7 day)
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/contract_code_current.sql
+++ b/models/marts/ledger_current_state/contract_code_current.sql
@@ -33,10 +33,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cc.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cc.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                cc.closed_at >= timestamp_sub(current_timestamp(), interval 7 day)
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/contract_data_current.sql
+++ b/models/marts/ledger_current_state/contract_data_current.sql
@@ -40,10 +40,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cd.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cd.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                cd.closed_at >= timestamp_sub(current_timestamp(), interval 7 day)
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/ttl_current.sql
+++ b/models/marts/ledger_current_state/ttl_current.sql
@@ -31,10 +31,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                ttl.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(ttl.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                ttl.closed_at >= timestamp_sub(current_timestamp(), interval 7 day)
         {% endif %}
     )
 

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -19,8 +19,8 @@ sources:
                 - last_modified_ledger
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: account_id, sequence_number, ledger_entry_change and last_modified_ledger."
         columns:
@@ -29,105 +29,105 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: balance
             description: '{{ doc("balance") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: buying_liabilities
             description: '{{ doc("buying_liabilities") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: selling_liabilities
             description: '{{ doc("selling_liabilities") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sequence_number
             description: '{{ doc("sequence_number") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: num_subentries
             description: '{{ doc("num_subentries") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: inflation_destination
             description: '{{ doc("inflation_destination") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: flags
             description: '{{ doc("flags_accounts_balances") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: home_domain
             description: '{{ doc("home_domain") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: master_weight
             description: '{{ doc("master_weight") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: threshold_low
             description: '{{ doc("threshold_low") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: threshold_medium
             description: '{{ doc("threshold_medium") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: threshold_high
             description: '{{ doc("threshold_high") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: last_modified_ledger
             description: '{{ doc("last_modified_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_entry_change
             description: '{{ doc("ledger_entry_change") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values: [0, 1, 2]
                   quote: false
@@ -137,7 +137,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sponsor
             description: '{{ doc("sponsor") }}'
@@ -147,46 +147,53 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: num_sponsoring
             description: '{{ doc("num_sponsoring") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sequence_ledger
             description: '{{ doc("sequence_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sequence_time
             description: '{{ doc("sequence_time") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
+
+          - name: closed_at
+            description: '{{ doc("closed_at") }}'
+            tests:
+              - not_null:
+                  config:
+                    where: closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -19,8 +19,8 @@ sources:
                 - last_modified_ledger
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: account_id, signer, ledger_entry_change and last_modified_ledger."
         columns:
@@ -29,21 +29,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: signer
             description: '{{ doc("signer") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: weight
             description: '{{ doc("weight") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sponsor
             description: '{{ doc("sponsor") }}'
@@ -53,25 +53,32 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
+
+          - name: closed_at
+            description: '{{ doc("closed_at") }}'
+            tests:
+              - not_null:
+                  config:
+                    where: closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_claimable_balances.yml
+++ b/models/sources/src_claimable_balances.yml
@@ -17,8 +17,8 @@ sources:
                 - ledger_entry_change
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: balance_id and ledger_entry_change."
 
@@ -28,7 +28,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: claimants
             description: '{{ doc("claimants") }}'
@@ -56,7 +56,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_code
             description: '{{ doc("asset_code") }}'
@@ -64,7 +64,7 @@ sources:
               - not_null:
                   config:
                     where: asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_issuer
             description: '{{ doc("asset_issuer") }}'
@@ -72,42 +72,42 @@ sources:
               - not_null:
                   config:
                     where: asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_amount
             description: '{{ doc("asset_amount") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sponsor
             description: '{{ doc("sponsor") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: flags
             description: '{{ doc("flags_accounts_balances") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: last_modified_ledger
             description: '{{ doc("last_modified_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_entry_change
             description: '{{ doc("ledger_entry_change") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values: [0, 1, 2]
                   quote: false
@@ -117,32 +117,39 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_run_date
+          - name: batch_run_date 
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_id
             description: '{{ doc("asset_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
+
+          - name: closed_at
+            description: '{{ doc("closed_at") }}'
+            tests:
+              - not_null:
+                  config:
+                    where: closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -17,7 +17,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: address_muxed
             description: '{{ doc("address_muxed") }}'
@@ -27,21 +27,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: type
             description: '{{ doc("type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: type_string
             description: '{{ doc("type_string") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: details
             description: '{{ doc("details_effects") }}'
@@ -51,21 +51,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: details.liquidity_pool
             description: '{{ doc("details_liquidity_pool") }}'
@@ -318,4 +318,4 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -18,18 +18,18 @@ sources:
               - unique:
                   config:
                     where:
-                      batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                      and batch_run_date < datetime_trunc(current_datetime(), day)
+                      closed_at >= timestamp_trunc(timestamp_sub(current_timestamp - interval 2 day
+                      and closed_at < timestamp_trunc(current_timestamp - interval 2 day
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: source_account
             description: '{{ doc("source_account") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: source_account_muxed
             description: '{{ doc("source_account_muxed") }}'
@@ -39,21 +39,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: type
             description: '{{ doc("type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: type_string
             description: '{{ doc("type_string") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: details
             description: '{{ doc("details") }}'
@@ -363,21 +363,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: details.asset_balance_changes
             description: '{{ doc("details_asset_balance_changes") }}'
@@ -414,7 +414,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: details_json
             description: '{{ doc("details") }}'

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -18,25 +18,25 @@ sources:
               - unique:
                   config:
                     where:
-                      batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                      and batch_run_date < datetime_trunc(current_datetime(), day)
+                      closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                      and closed_at < timestamp_trunc(current_timestamp(), day)
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: transaction_hash
             description: '{{ doc("transaction_hash") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_sequence
             description: '{{ doc("ledger_sequence") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: application_order
             description: '{{ doc("application_order") }}'
@@ -46,42 +46,42 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: account_sequence
             description: '{{ doc("account_sequence") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: max_fee
             description: '{{ doc("max_fee") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: operation_count
             description: '{{ doc("transaction_operation_count") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: created_at
             description: '{{ doc("created_at") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: memo_type
             description: '{{ doc("memo_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: memo
             description: '{{ doc("memo") }}'
@@ -91,21 +91,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: successful
             description: '{{ doc("successful") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: fee_charged
             description: '{{ doc("fee_charged") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: inner_transaction_hash
             description: '{{ doc("inner_transaction_hash") }}'
@@ -142,56 +142,56 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: tx_result
             description: '{{ doc("tx_result") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: tx_meta
             description: '{{ doc("tx_meta") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: tx_fee_meta
             description: '{{ doc("tx_fee_meta") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: resource_fee
             description: '{{ doc("resource_fee") }}'

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -18,8 +18,8 @@ sources:
                 - last_modified_ledger
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: liquidity_pool_id, ledger_entry_change and last_modified_ledger."
         columns:
@@ -28,49 +28,49 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: type
             description: '{{ doc("pool_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: fee
             description: '{{ doc("fee") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: trustline_count
             description: '{{ doc("trustline_count") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: pool_share_count
             description: '{{ doc("pool_share_count") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_a_id
             description: '{{ doc("asset_a_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_a_type
             description: '{{ doc("asset_a_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_a_code
             description: '{{ doc("asset_a_code") }}'
@@ -78,7 +78,7 @@ sources:
               - not_null:
                   config:
                     where: asset_a_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_a_issuer
             description: '{{ doc("asset_a_issuer") }}'
@@ -86,28 +86,28 @@ sources:
               - not_null:
                   config:
                     where: asset_a_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_a_amount
             description: '{{ doc("asset_a_amount") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_b_id
             description: '{{ doc("asset_b_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_b_type
             description: '{{ doc("asset_a_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_b_code
             description: '{{ doc("asset_a_code") }}'
@@ -115,7 +115,7 @@ sources:
               - not_null:
                   config:
                     where: asset_b_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_b_issuer
             description: '{{ doc("asset_a_issuer") }}'
@@ -123,28 +123,28 @@ sources:
               - not_null:
                   config:
                     where: asset_b_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_b_amount
             description: '{{ doc("asset_a_amount") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: last_modified_ledger
             description: '{{ doc("last_modified_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_entry_change
             description: '{{ doc("ledger_entry_change") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values: [0, 1, 2]
                   quote: false
@@ -154,25 +154,32 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
+
+          - name: closed_at
+            description: '{{ doc("closed_at") }}'
+            tests:
+              - not_null:
+                  config:
+                    where: closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -18,8 +18,8 @@ sources:
                 - last_modified_ledger
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: offer_id, ledger_entry_change and last_modified_ledger."
         columns:
@@ -28,21 +28,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: offer_id
             description: '{{ doc("offer_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: selling_asset_type
             description: '{{ doc("asset_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: selling_asset_code
             description: '{{ doc("asset_code") }}'
@@ -50,7 +50,7 @@ sources:
               - not_null:
                   config:
                     where: selling_asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: selling_asset_issuer
             description: '{{ doc("asset_issuer") }}'
@@ -58,14 +58,14 @@ sources:
               - not_null:
                   config:
                     where: selling_asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: buying_asset_type
             description: '{{ doc("asset_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: buying_asset_code
             description: '{{ doc("asset_code") }}'
@@ -73,7 +73,7 @@ sources:
               - not_null:
                   config:
                     where: buying_asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: buying_asset_issuer
             description: '{{ doc("asset_issuer") }}'
@@ -81,56 +81,56 @@ sources:
               - not_null:
                   config:
                     where: buying_asset_type != 'native'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: amount
             description: '{{ doc("amount") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: pricen
             description: '{{ doc("price_n") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: priced
             description: '{{ doc("price_d") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: price
             description: '{{ doc("price") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: flags
             description: '{{ doc("flags_offers") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: last_modified_ledger
             description: '{{ doc("last_modified_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_entry_change
             description: '{{ doc("ledger_entry_change") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values: [0, 1, 2]
                   quote: false
@@ -140,7 +140,7 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sponsor
             description: '{{ doc("sponsor") }}'
@@ -150,42 +150,42 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: selling_asset_id
             description: '{{ doc("assets_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: buying_asset_id
             description: '{{ doc("assets_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_sequence
             description: '{{ doc("ledger_sequence") }}'

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -21,8 +21,8 @@ sources:
                 - last_modified_ledger
               config:
                 where:
-                  batch_run_date >= datetime_trunc(datetime_sub(current_datetime(), interval 2 day), day)
-                  and batch_run_date < datetime_trunc(current_datetime(), day)
+                  closed_at >= timestamp_trunc(timestamp_sub(current_timestamp(), interval 2 day), day)
+                  and closed_at < timestamp_trunc(current_timestamp(), day)
               meta:
                 description: "Tests the uniqueness combination of: account_id, asset_code, asset_issuer, liquidity_pool_id, ledger_entry_change and last_modified_ledger."
         columns:
@@ -31,21 +31,21 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: account_id
             description: '{{ doc("account_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: asset_type
             description: '{{ doc("asset_type") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values:
                     ["credit_alphanum4", "credit_alphanum12", "pool_share"]
@@ -56,7 +56,7 @@ sources:
               - not_null:
                   config:
                     where: asset_type != 'pool_share'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: asset_code
             description: '{{ doc("asset_code") }}'
@@ -64,63 +64,63 @@ sources:
               - not_null:
                   config:
                     where: asset_type != 'pool_share'
-                      and batch_run_date > current_datetime - interval 2 day
+                      and closed_at > current_timestamp - interval 2 day
 
           - name: liquidity_pool_id
             description: '{{ doc("liquidity_pool_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: balance
             description: '{{ doc("trust_balance") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: trust_line_limit
             description: '{{ doc("trust_line_limit") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: buying_liabilities
             description: '{{ doc("buying_liabilities") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: selling_liabilities
             description: '{{ doc("selling_liabilities") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: flags
             description: '{{ doc("flags_trust_lines") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: last_modified_ledger
             description: '{{ doc("last_modified_ledger") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_entry_change
             description: '{{ doc("ledger_entry_change") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
               - accepted_values:
                   values: [0, 1, 2]
                   quote: false
@@ -130,28 +130,28 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_id
             description: '{{ doc("batch_id") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_run_date
             description: '{{ doc("batch_run_date") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: batch_insert_ts
             description: '{{ doc("batch_insert_ts") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: sponsor
             description: '{{ doc("sponsor") }}'
@@ -161,14 +161,14 @@ sources:
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:
               - not_null:
                   config:
-                    where: batch_run_date > current_datetime - interval 2 day
+                    where: closed_at > current_timestamp - interval 2 day
 
           - name: ledger_sequence
             description: '{{ doc("ledger_sequence") }}'


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

Changing dbt models to use `closed_at` instead of `batch_run_date`

### Why

Part of https://stellarorg.atlassian.net/browse/HUBBLE-342 
Make all tables partitioned on `closed_at` for a better and more consistent user experience

### Known limitations

* Need to test on testnet and pubnet data
* Need to find metabase queries that will be impacted and update them as well