### PR TITLE
Remove metadates (batch_insert_ts and upstream_insert_ts)

### DIFF
--- a/models/docs/universal.md
+++ b/models/docs/universal.md
@@ -75,6 +75,10 @@ String representation of the run id for a given DAG in Airflow. Takes the form o
 The start date for the batch interval. When taken with the date in the batch_id, the date represents the interval of ledgers processed. The batch run date can be seen as a proxy of closed_at for a ledger.
 {% enddocs %}
 
+{% docs batch_insert_ts %}
+The timestamp in UTC when a batch of records was inserted into the database. This field can help identify if a batch executed in real time or as part of a backfill. The timestamp should not be used during ad hoc analysis and is useful for data engineering purposes.
+{% enddocs %}
+
 {% docs address %}
 The address of the account. The address is the account's public key encoded in base32. All account addresses start with a `G`
 {% enddocs %}

--- a/models/docs/universal.md
+++ b/models/docs/universal.md
@@ -19,10 +19,6 @@ The Farm Hash encoding of Asset Code + Asset Issuer + Asset Type. This field is 
 Current snapshot tables (tables that end in `*_current`) require a singular, unique identifier so that only records that change are updated. This column is a concatenation of the natural keys to create a unique key.
 {% enddocs %}
 
-{% docs upstream_insert_ts %}
-The timestamp in UTC when a batch of records was inserted into an upstream table. This field can help identify gaps in data as well as improve rerun capabilities. The timestamp should not be used during ad hoc analysis and is useful for data engineering purposes.
-{% enddocs %}
-
 {% docs asset_code %}
 The 4 or 12 character code representation of the asset on the network.
 
@@ -77,10 +73,6 @@ String representation of the run id for a given DAG in Airflow. Takes the form o
 
 {% docs batch_run_date %}
 The start date for the batch interval. When taken with the date in the batch_id, the date represents the interval of ledgers processed. The batch run date can be seen as a proxy of closed_at for a ledger.
-{% enddocs %}
-
-{% docs batch_insert_ts %}
-The timestamp in UTC when a batch of records was inserted into the database. This field can help identify if a batch executed in real time or as part of a backfill. The timestamp should not be used during ad hoc analysis and is useful for data engineering purposes.
 {% enddocs %}
 
 {% docs address %}

--- a/models/intermediate/trades/int_trade_agg_day.sql
+++ b/models/intermediate/trades/int_trade_agg_day.sql
@@ -232,5 +232,7 @@ with
     )
 
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from join_table_daily

--- a/models/intermediate/trades/int_trade_agg_month.sql
+++ b/models/intermediate/trades/int_trade_agg_month.sql
@@ -233,5 +233,7 @@ with
     )
 
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from join_table_monthly

--- a/models/intermediate/trades/int_trade_agg_week.sql
+++ b/models/intermediate/trades/int_trade_agg_week.sql
@@ -233,5 +233,7 @@ with
     )
 
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from join_table_weekly

--- a/models/intermediate/trades/int_trade_agg_year.sql
+++ b/models/intermediate/trades/int_trade_agg_year.sql
@@ -239,5 +239,7 @@ with
     )
 
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from join_table_yearly

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -394,5 +394,7 @@ with
             on hist_trans.ledger_sequence = hist_ledg.sequence
     )
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from enriched_operations

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -30,7 +30,6 @@ with
             , failed_transaction_count
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from {{ ref('stg_history_ledgers') }}
         where
             cast(batch_run_date as date) < date_add(date('{{ dbt_airflow_macros.ds() }}'), interval 2 day)
@@ -67,7 +66,6 @@ with
             , extra_signers
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , resource_fee
             , soroban_resources_instructions
             , soroban_resources_read_bytes
@@ -195,7 +193,6 @@ with
             , type_string
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , asset_balance_changes
             , parameters
             , parameters_decoded
@@ -390,7 +387,6 @@ with
             -- general fields
             , hist_ops.batch_id
             , hist_ops.batch_run_date
-            , current_timestamp() as batch_insert_ts
         from history_operations as hist_ops
         join history_transactions as hist_trans
             on hist_ops.transaction_id = hist_trans.transaction_id

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -586,13 +586,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: asset_balance_changes
         description: '{{ doc("details_asset_balance_changes") }}'
 

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -83,7 +83,6 @@ with
             -- general fields
             , enriched.batch_id
             , enriched.batch_run_date
-            , enriched.batch_insert_ts
         from {{ ref('enriched_history_operations') }} as enriched
         where
             enriched.type in (24, 25, 26)

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -92,5 +92,7 @@ with
             {% endif %}
     )
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from eho_soroban

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -256,13 +256,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: transaction_result_code
         description: '{{ doc("transaction_result_code") }}'
 

--- a/models/marts/fee_stats_agg.sql
+++ b/models/marts/fee_stats_agg.sql
@@ -158,6 +158,7 @@ with
             , agg_stats.max_ledger_sequence
             , surge_stats.total_ledgers
             , 100 * (surge_stats.surge_price_count / surge_stats.total_ledgers) as surge_price_pct
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from agg_stats
         inner join
             surge_stats on

--- a/models/marts/history_assets.sql
+++ b/models/marts/history_assets.sql
@@ -80,5 +80,7 @@
 
 {% endif %}
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from add_assets

--- a/models/marts/history_assets.sql
+++ b/models/marts/history_assets.sql
@@ -47,7 +47,6 @@
                 , exclude_duplicates.asset_issuer
                 , new_load.batch_id
                 , new_load.batch_run_date
-                , new_load.batch_insert_ts
             from exclude_duplicates
             left join
                 new_load on
@@ -76,7 +75,6 @@
                 , asset_issuer
                 , batch_id
                 , batch_run_date
-                , batch_insert_ts
             from prep_dedup
         )
 

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -61,4 +61,3 @@ models:
           - incremental_not_null:
               date_column_name: "batch_run_date"
               greater_than_equal_to: "2 day"
-

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -63,10 +63,3 @@ models:
           - not_null:
               config:
                 where: batch_run_date > current_datetime - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: batch_run_date > current_datetime - interval 2 day

--- a/models/marts/ledger_current_state/account_signers_current.sql
+++ b/models/marts/ledger_current_state/account_signers_current.sql
@@ -52,5 +52,6 @@ select
     , deleted
     , unique_id
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_signers
 where row_nr = 1

--- a/models/marts/ledger_current_state/account_signers_current.sql
+++ b/models/marts/ledger_current_state/account_signers_current.sql
@@ -38,7 +38,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(s.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(s.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
     )
 select

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -90,20 +90,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: unique_id
         description: '{{ doc("unique_id") }}'
         tests:

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -37,7 +37,6 @@ with
             , a.sequence_ledger
             , a.sequence_time
             , a.batch_run_date
-            , a.batch_insert_ts
             , row_number()
                 over (
                     partition by a.account_id
@@ -53,10 +52,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                a.batch_run_date >= date_sub(current_date(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(a.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                TIMESTAMP(a.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
         {% endif %}
     )
 
@@ -107,6 +103,4 @@ select
     , sequence_ledger
     , sequence_time
     , batch_run_date
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
 from get_creation_account

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -52,7 +52,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(a.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(a.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -103,4 +103,5 @@ select
     , sequence_ledger
     , sequence_time
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from get_creation_account

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -186,17 +186,3 @@ models:
           - not_null:
               config:
                 where: closed_at > current_timestamp - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day

--- a/models/marts/ledger_current_state/claimable_balances_current.sql
+++ b/models/marts/ledger_current_state/claimable_balances_current.sql
@@ -25,7 +25,6 @@ with
             , cb.deleted
             , cb.batch_id
             , cb.batch_run_date
-            , cb.batch_insert_ts
             , cb.closed_at
             , cb.ledger_sequence
             , row_number()
@@ -37,7 +36,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cb.batch_run_date >= date_sub(current_date(), interval 2 day)
+                TIMESTAMP(cb.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 2 DAY )
         {% endif %}
     )
 
@@ -57,7 +56,5 @@ select
     , batch_run_date
     , closed_at
     , ledger_sequence
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
 from current_balance
 where rn = 1

--- a/models/marts/ledger_current_state/claimable_balances_current.sql
+++ b/models/marts/ledger_current_state/claimable_balances_current.sql
@@ -56,5 +56,6 @@ select
     , batch_run_date
     , closed_at
     , ledger_sequence
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_balance
 where rn = 1

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -120,17 +120,3 @@ models:
           - not_null:
               config:
                 where: batch_run_date > current_datetime - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: batch_run_date > current_datetime - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: batch_run_date > current_datetime - interval 2 day

--- a/models/marts/ledger_current_state/config_settings_current.sql
+++ b/models/marts/ledger_current_state/config_settings_current.sql
@@ -126,5 +126,6 @@ select
     , deleted
     , batch_id
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_settings
 where rn = 1

--- a/models/marts/ledger_current_state/config_settings_current.sql
+++ b/models/marts/ledger_current_state/config_settings_current.sql
@@ -61,7 +61,6 @@ with
             , cfg.deleted
             , cfg.batch_id
             , cfg.batch_run_date
-            , cfg.batch_insert_ts
             , cfg.ledger_sequence
             , row_number()
                 over (
@@ -72,10 +71,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cfg.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cfg.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                TIMESTAMP(cfg.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
         {% endif %}
     )
 
@@ -130,7 +126,5 @@ select
     , deleted
     , batch_id
     , batch_run_date
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
 from current_settings
 where rn = 1

--- a/models/marts/ledger_current_state/config_settings_current.sql
+++ b/models/marts/ledger_current_state/config_settings_current.sql
@@ -71,7 +71,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                TIMESTAMP(cfg.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(cfg.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/config_settings_current.yml
+++ b/models/marts/ledger_current_state/config_settings_current.yml
@@ -140,17 +140,11 @@ models:
       - name: batch_run_date
         description: '{{ doc("batch_run_date") }}'
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-
       - name: closed_at
         description: '{{ doc("closed_at") }}'
 
       - name: deleted
         description: '{{ doc("deleted") }}'
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
 
       - name: last_modified_ledger
         description: '{{ doc("last_modified_ledger") }}'

--- a/models/marts/ledger_current_state/contract_code_current.sql
+++ b/models/marts/ledger_current_state/contract_code_current.sql
@@ -47,5 +47,6 @@ select
     , deleted
     , batch_id
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_code
 where rn = 1

--- a/models/marts/ledger_current_state/contract_code_current.sql
+++ b/models/marts/ledger_current_state/contract_code_current.sql
@@ -32,7 +32,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                TIMESTAMP(cc.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(cc.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/contract_code_current.sql
+++ b/models/marts/ledger_current_state/contract_code_current.sql
@@ -21,7 +21,6 @@ with
             , cc.deleted
             , cc.batch_id
             , cc.batch_run_date
-            , cc.batch_insert_ts
             , cc.ledger_sequence
             , cc.ledger_key_hash
             , row_number()
@@ -33,10 +32,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cc.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cc.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                TIMESTAMP(cc.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
         {% endif %}
     )
 
@@ -51,7 +47,5 @@ select
     , deleted
     , batch_id
     , batch_run_date
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
 from current_code
 where rn = 1

--- a/models/marts/ledger_current_state/contract_code_current.yml
+++ b/models/marts/ledger_current_state/contract_code_current.yml
@@ -70,17 +70,3 @@ models:
           - not_null:
               config:
                 where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day

--- a/models/marts/ledger_current_state/contract_data_current.sql
+++ b/models/marts/ledger_current_state/contract_data_current.sql
@@ -39,7 +39,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                TIMESTAMP(cd.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(cd.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/contract_data_current.sql
+++ b/models/marts/ledger_current_state/contract_data_current.sql
@@ -61,5 +61,6 @@ select
     , batch_id
     , batch_run_date
     , unique_id
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_data
 where rn = 1

--- a/models/marts/ledger_current_state/contract_data_current.sql
+++ b/models/marts/ledger_current_state/contract_data_current.sql
@@ -27,7 +27,6 @@ with
             , cd.deleted
             , cd.batch_id
             , cd.batch_run_date
-            , cd.batch_insert_ts
             , cd.ledger_sequence
             , cd.ledger_key_hash
             , concat(cd.contract_id, '-', cd.ledger_key_hash) as unique_id
@@ -40,10 +39,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                cd.closed_at >= timestamp_sub(current_timestamp(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(cd.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                TIMESTAMP(cd.closed_at) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
         {% endif %}
     )
 
@@ -64,8 +60,6 @@ select
     , deleted
     , batch_id
     , batch_run_date
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
     , unique_id
 from current_data
 where rn = 1

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -108,20 +108,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: unique_id
         description: '{{ doc("unique_id") }}'
         tests:

--- a/models/marts/ledger_current_state/liquidity_pools_current.sql
+++ b/models/marts/ledger_current_state/liquidity_pools_current.sql
@@ -36,7 +36,6 @@ with
             , l.closed_at
             , lp.deleted
             , lp.batch_run_date
-            , lp.batch_insert_ts
             , row_number()
                 over (
                     partition by lp.liquidity_pool_id
@@ -49,10 +48,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                lp.batch_run_date >= date_sub(current_date(), interval 30 day)
-                -- fetch the last week of records loaded
-                and timestamp_add(lp.batch_insert_ts, interval 7 day)
-                > (select max(t.upstream_insert_ts) from {{ this }} as t)
+                TIMESTAMP(lp.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
         {% endif %}
 
     )
@@ -75,7 +71,5 @@ select
     , closed_at
     , deleted
     , batch_run_date
-    , batch_insert_ts as upstream_insert_ts
-    , current_timestamp() as batch_insert_ts
 from current_lps
 where row_nr = 1

--- a/models/marts/ledger_current_state/liquidity_pools_current.sql
+++ b/models/marts/ledger_current_state/liquidity_pools_current.sql
@@ -48,7 +48,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(lp.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(lp.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
 
     )

--- a/models/marts/ledger_current_state/liquidity_pools_current.sql
+++ b/models/marts/ledger_current_state/liquidity_pools_current.sql
@@ -71,5 +71,6 @@ select
     , closed_at
     , deleted
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_lps
 where row_nr = 1

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -171,17 +171,3 @@ models:
           - not_null:
               config:
                 where: closed_at > current_timestamp - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day

--- a/models/marts/ledger_current_state/offers_current.sql
+++ b/models/marts/ledger_current_state/offers_current.sql
@@ -42,7 +42,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(o.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(o.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
 
     )

--- a/models/marts/ledger_current_state/offers_current.sql
+++ b/models/marts/ledger_current_state/offers_current.sql
@@ -66,5 +66,6 @@ select
     , deleted
     , sponsor
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_offers
 where row_nr = 1

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -176,17 +176,3 @@ models:
           - not_null:
               config:
                 where: closed_at > current_timestamp - interval 2 day
-
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day

--- a/models/marts/ledger_current_state/trust_lines_current.sql
+++ b/models/marts/ledger_current_state/trust_lines_current.sql
@@ -45,7 +45,7 @@ with
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                TIMESTAMP(tl.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 DAYS )
+                TIMESTAMP(tl.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
         {% endif %}
 
     )

--- a/models/marts/ledger_current_state/trust_lines_current.sql
+++ b/models/marts/ledger_current_state/trust_lines_current.sql
@@ -67,5 +67,6 @@ select
     , deleted
     , unique_id
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_tls
 where row_nr = 1

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -145,20 +145,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: unique_id
         description: '{{ doc("unique_id") }}'
         tests:

--- a/models/marts/ledger_current_state/ttl_current.sql
+++ b/models/marts/ledger_current_state/ttl_current.sql
@@ -43,5 +43,6 @@ select
     , deleted
     , batch_id
     , batch_run_date
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from current_expiration
 where rn = 1

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -34,13 +34,6 @@ models:
               config:
                 where: closed_at > current_timestamp - interval 2 day
 
-      - name: batch_insert_ts
-        description: '{{ doc("batch_insert_ts") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
       - name: closed_at
         description: '{{ doc("closed_at") }}'
         tests:
@@ -50,13 +43,6 @@ models:
 
       - name: deleted
         description: '{{ doc("deleted") }}'
-        tests:
-          - not_null:
-              config:
-                where: closed_at > current_timestamp - interval 2 day
-
-      - name: upstream_insert_ts
-        description: '{{ doc("upstream_insert_ts") }}'
         tests:
           - not_null:
               config:

--- a/models/marts/trade_agg.sql
+++ b/models/marts/trade_agg.sql
@@ -112,5 +112,7 @@ with
             and join_table_yearly.asset_b = join_table_daily.asset_b
     )
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from join_trades

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -183,10 +183,3 @@ sources:
               - not_null:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
-
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -181,3 +181,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -66,3 +66,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -68,10 +68,3 @@ sources:
               - not_null:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
-
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day

--- a/models/sources/src_claimable_balances.yml
+++ b/models/sources/src_claimable_balances.yml
@@ -133,13 +133,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: asset_id
             description: '{{ doc("asset_id") }}'
             tests:

--- a/models/sources/src_claimable_balances.yml
+++ b/models/sources/src_claimable_balances.yml
@@ -137,3 +137,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -190,13 +190,6 @@ sources:
                   config:
                     where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: closed_at > current_timestamp - interval 2 day
-
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -194,3 +194,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -142,13 +142,6 @@ sources:
                   config:
                     where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: closed_at > current_timestamp - interval 2 day
-
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -146,3 +146,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -134,13 +134,6 @@ sources:
                   config:
                     where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: closed_at > current_timestamp - interval 2 day
-
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -140,3 +140,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -56,3 +56,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -56,10 +56,3 @@ sources:
               - not_null:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
-
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -332,3 +332,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -73,13 +73,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: details.liquidity_pool
             description: '{{ doc("details_liquidity_pool") }}'
 

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -170,3 +170,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -149,12 +149,6 @@ sources:
                   config:
                     where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: closed_at > current_timestamp - interval 2 day
           - name: soroban_fee_write_1kb
             description: '{{ doc("soroban_fee_write_1kb") }}'
 

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -402,13 +402,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: details.asset_balance_changes
             description: '{{ doc("details_asset_balance_changes") }}'
 

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -439,3 +439,10 @@ sources:
 
           - name: details_json
             description: '{{ doc("details") }}'
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -183,10 +183,3 @@ sources:
               - not_null:
                   config:
                     where: ledger_closed_at > current_timestamp - interval 2 day
-
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: ledger_closed_at > current_timestamp - interval 2 day

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -181,3 +181,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "ledger_closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -221,3 +221,10 @@ sources:
 
           - name: refundable_fee
             description: '{{ doc("refundable_fee") }}'
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -181,13 +181,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -169,10 +169,3 @@ sources:
               - not_null:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
-
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -167,3 +167,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "batch_run_date"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -159,13 +159,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: selling_asset_id
             description: '{{ doc("assets_id") }}'
             tests:

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -180,3 +180,10 @@ sources:
 
           - name: ledger_sequence
             description: '{{ doc("ledger_sequence") }}'
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -146,13 +146,6 @@ sources:
                   config:
                     where: batch_run_date > current_datetime - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: batch_run_date > current_datetime - interval 2 day
-
           - name: sponsor
             description: '{{ doc("sponsor") }}'
 

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -161,3 +161,10 @@ sources:
 
           - name: ledger_sequence
             description: '{{ doc("ledger_sequence") }}'
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -76,13 +76,6 @@ sources:
                   config:
                     where: closed_at > current_timestamp - interval 2 day
 
-          - name: batch_insert_ts
-            description: '{{ doc("batch_insert_ts") }}'
-            tests:
-              - not_null:
-                  config:
-                    where: closed_at > current_timestamp - interval 2 day
-
           - name: closed_at
             description: '{{ doc("closed_at") }}'
             tests:

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -79,3 +79,10 @@ sources:
               - incremental_not_null:
                   date_column_name: "closed_at"
                   greater_than_equal_to: "2 day"
+
+          - name: batch_insert_ts
+            description: '{{ doc("batch_insert_ts") }}'
+            tests:
+              - incremental_not_null:
+                  date_column_name: "closed_at"
+                  greater_than_equal_to: "2 day"

--- a/models/staging/stg_account_signers.sql
+++ b/models/staging/stg_account_signers.sql
@@ -23,6 +23,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_account_signers.sql
+++ b/models/staging/stg_account_signers.sql
@@ -20,7 +20,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_account_signers.sql
+++ b/models/staging/stg_account_signers.sql
@@ -22,6 +22,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_accounts.sql
+++ b/models/staging/stg_accounts.sql
@@ -36,6 +36,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_accounts.sql
+++ b/models/staging/stg_accounts.sql
@@ -37,6 +37,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_accounts.sql
+++ b/models/staging/stg_accounts.sql
@@ -34,7 +34,6 @@ with
             , sequence_time
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -28,6 +28,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -27,6 +27,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -25,7 +25,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_config_settings.sql
+++ b/models/staging/stg_config_settings.sql
@@ -61,6 +61,7 @@ with
             , deleted
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_config_settings.sql
+++ b/models/staging/stg_config_settings.sql
@@ -62,6 +62,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_config_settings.sql
+++ b/models/staging/stg_config_settings.sql
@@ -61,7 +61,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_code.sql
+++ b/models/staging/stg_contract_code.sql
@@ -31,7 +31,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_code.sql
+++ b/models/staging/stg_contract_code.sql
@@ -32,6 +32,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_code.sql
+++ b/models/staging/stg_contract_code.sql
@@ -31,6 +31,7 @@ with
             , deleted
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_data.sql
+++ b/models/staging/stg_contract_data.sql
@@ -32,7 +32,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_data.sql
+++ b/models/staging/stg_contract_data.sql
@@ -32,6 +32,7 @@ with
             , deleted
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_contract_data.sql
+++ b/models/staging/stg_contract_data.sql
@@ -33,6 +33,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_assets.sql
+++ b/models/staging/stg_history_assets.sql
@@ -22,5 +22,7 @@ with
         where dedup_oldest_asset = 1
     )
 
-select *
+select
+    *
+    , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 from new_load_dedup

--- a/models/staging/stg_history_effects.sql
+++ b/models/staging/stg_history_effects.sql
@@ -82,7 +82,6 @@ with
             , closed_at
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_effects.sql
+++ b/models/staging/stg_history_effects.sql
@@ -83,6 +83,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_effects.sql
+++ b/models/staging/stg_history_effects.sql
@@ -82,6 +82,7 @@ with
             , closed_at
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_ledgers.sql
+++ b/models/staging/stg_history_ledgers.sql
@@ -33,7 +33,6 @@ with
             , soroban_fee_write_1kb
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_ledgers.sql
+++ b/models/staging/stg_history_ledgers.sql
@@ -33,6 +33,7 @@ with
             , soroban_fee_write_1kb
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_ledgers.sql
+++ b/models/staging/stg_history_ledgers.sql
@@ -34,6 +34,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_operations.sql
+++ b/models/staging/stg_history_operations.sql
@@ -141,7 +141,6 @@ with
             , closed_at
             , batch_id
             , batch_run_date
-            , batch_insert_ts
 
         from raw_table
     )

--- a/models/staging/stg_history_operations.sql
+++ b/models/staging/stg_history_operations.sql
@@ -142,6 +142,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
 
         from raw_table
     )

--- a/models/staging/stg_history_operations.sql
+++ b/models/staging/stg_history_operations.sql
@@ -141,6 +141,7 @@ with
             , closed_at
             , batch_id
             , batch_run_date
+            , batch_insert_ts
 
         from raw_table
     )

--- a/models/staging/stg_history_trades.sql
+++ b/models/staging/stg_history_trades.sql
@@ -38,6 +38,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_trades.sql
+++ b/models/staging/stg_history_trades.sql
@@ -37,6 +37,7 @@ with
             , seller_is_exact
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_trades.sql
+++ b/models/staging/stg_history_trades.sql
@@ -37,7 +37,6 @@ with
             , seller_is_exact
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_transactions.sql
+++ b/models/staging/stg_history_transactions.sql
@@ -54,6 +54,7 @@ with
             , refundable_fee
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_transactions.sql
+++ b/models/staging/stg_history_transactions.sql
@@ -55,6 +55,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_history_transactions.sql
+++ b/models/staging/stg_history_transactions.sql
@@ -54,7 +54,6 @@ with
             , refundable_fee
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -33,6 +33,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -34,6 +34,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -31,7 +31,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_offers.sql
+++ b/models/staging/stg_offers.sql
@@ -32,7 +32,6 @@ with
             , deleted
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_offers.sql
+++ b/models/staging/stg_offers.sql
@@ -34,6 +34,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_offers.sql
+++ b/models/staging/stg_offers.sql
@@ -35,6 +35,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_trust_lines.sql
+++ b/models/staging/stg_trust_lines.sql
@@ -29,7 +29,6 @@ with
             , sponsor
             , batch_id
             , batch_run_date
-            , batch_insert_ts
             , closed_at
             , ledger_sequence
         from raw_table

--- a/models/staging/stg_trust_lines.sql
+++ b/models/staging/stg_trust_lines.sql
@@ -32,6 +32,7 @@ with
             , closed_at
             , ledger_sequence
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_trust_lines.sql
+++ b/models/staging/stg_trust_lines.sql
@@ -31,6 +31,7 @@ with
             , batch_run_date
             , closed_at
             , ledger_sequence
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_ttl.sql
+++ b/models/staging/stg_ttl.sql
@@ -21,6 +21,7 @@ with
             , batch_id
             , batch_run_date
             , batch_insert_ts
+            , '{{ var("airflow_start_timestamp") }}' as airflow_start_ts
         from raw_table
     )
 

--- a/models/staging/stg_ttl.sql
+++ b/models/staging/stg_ttl.sql
@@ -20,6 +20,7 @@ with
             , closed_at
             , batch_id
             , batch_run_date
+            , batch_insert_ts
         from raw_table
     )
 

--- a/models/staging/stg_ttl.sql
+++ b/models/staging/stg_ttl.sql
@@ -20,7 +20,6 @@ with
             , closed_at
             , batch_id
             , batch_run_date
-            , batch_insert_ts
         from raw_table
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ elementary-data[bigquery]==0.15.1
 MarkupSafe==2.0.1
 pre-commit==3.5.0
 pytz==2022.7.1
-sqlfluff==3.0.5
-sqlfluff-templater-dbt==3.0.5
+sqlfluff==3.0.7
+sqlfluff-templater-dbt==3.0.7


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

In this PR, we get rid of `batch_insert_ts` and `upstream_insert_ts`. Also, all `current_*` timestamps in sql are changed to use airflow execution ts

### Why

`batch_insert_ts` and `upstream_insert_ts` uses arbitrary value of timestamp, which can lessen the performance of the warehouse. Also, makes pipelines non idempotent.

### Known limitations

None