### PR TITLE
Use right columns in source history trades (Jenkin failed)

### DIFF
--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -54,7 +54,7 @@ sources:
               - incremental_not_null:
                   date_column_name: "ledger_closed_at"
                   greater_than_equal_to: "2 day"
-                  condition: 'asset_type != "native"'
+                  condition: 'selling_asset_type != "native"'
 
           - name: selling_asset_issuer
             description: '{{ doc("trade_selling_asset_issuer") }}'
@@ -62,7 +62,7 @@ sources:
               - incremental_not_null:
                   date_column_name: "ledger_closed_at"
                   greater_than_equal_to: "2 day"
-                  condition: 'asset_type != "native"'
+                  condition: 'selling_asset_type != "native"'
 
           - name: selling_asset_type
             description: '{{ doc("trade_selling_asset_type") }}'


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

When I merged my last PR, the jenkins job failed with following errors:

```
[0m07:04:45  [31mCompleted with 2 errors and 15 warnings:[0m
[0m07:04:45  
[0m07:04:45    Database Error in test source_incremental_not_null_crypto_stellar_history_trades_selling_asset_issuer__asset_type_native___ledger_closed_at__2_day (models/sources/src_history_trades.yml)
  Unrecognized name: asset_type at [23:13]
  compiled Code at target/run/stellar_dbt_public/models/sources/src_history_trades.yml/source_incremental_not_null_cr_686c7a09c5f5b309bc224a19c201b55a.sql
[0m07:04:45  
[0m07:04:45    Database Error in test source_incremental_not_null_crypto_stellar_history_trades_selling_asset_code__asset_type_native___ledger_closed_at__2_day (models/sources/src_history_trades.yml)
  Unrecognized name: asset_type at [23:13]
  compiled Code at target/run/stellar_dbt_public/models/sources/src_history_trades.yml/source_incremental_not_null_cr_2de8ea94a9abc4e121b4b11b5e76ba72.sql
```
This PR helps to overcome above issue as I missed mentioning the right column names.

### Why

See above

### Known limitations

I would like to understand why it could not be caught during testing. Have seen the issue earlier as well.