### PR TITLE
Build docs for only `stellar_dbt_public`

### DIFF
--- a/.github/workflows/dbt-docs-website.yml
+++ b/.github/workflows/dbt-docs-website.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Generate dbt docs
         run: |
           dbt deps
-          dbt docs generate
+          dbt docs generate --select "stellar_dbt_public" --exclude "dbt_project_evaluator_exceptions"
 
       - id: "upload-folder"
         uses: "google-github-actions/upload-cloud-storage@v2"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -19,6 +19,9 @@ clean-targets: # directories to be removed by `dbt clean`
   - "target"
   - "dbt_packages"
 
+flags:
+  require_explicit_package_overrides_for_builtin_materializations: false
+
 vars:
   dbt_project_evaluator:
     documentation_coverage_target: 50


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

Changing the build docs CI definition to only build the catalog and manifest for the `stellar_dbt_public` project itself.

### Why

CI was failing due to elementary and dbt_project_evaluator datasets not existing. These datasets are private and built in an internal library. The dbt docs should not include these libraries as they are not pertinent to Stellar dataset. 

### Known limitations

I kept dbt_project_evaluator in the project and just explicitly excluded during build. We should look into removing the library entirely in the future.