### PR TITLE
Remove special characters from txn readme

### DIFF
--- a/models/docs/sources/history_transactions.md
+++ b/models/docs/sources/history_transactions.md
@@ -103,7 +103,7 @@ A transaction's success does not indicate whether it was included and written to
 {% enddocs %}
 
 {% docs fee_charged %}
-The fee (in stroops) paid by the source account to apply this transaction to the ledger. At minimum, a transaction is charged # of operations * base fee. The minimum base fee is 100 stroops
+The fee (in stroops) paid by the source account to apply this transaction to the ledger. At minimum, a transaction is charged the total number of operations contained within the transaction, multiplied by the base fee. The minimum base fee is 100 stroops
 
 #### Notes:
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

Strip special characters out of README descriptions to confirm if the special characters builds the `manifest.json` incorrectly. 
### Why

Schema descriptions are not appropriately updated in the test project, the pipeline fails with the following error:

```
application_order
BigQuery error in update operation: The description for field fee_charged is too
long. The maximum length is 1024 characters.
Error: Process completed with exit code 1.
```

If you look in Bigquery, the description contains metadata from manifest.json for the `fee_charged` field:

```
The fee (in stroops) paid by the source account to apply this transaction to the ledger. At minimum, a transaction is charged # of operations Makefile README.md account_signers_current_schema.txt account_signers_schema.txt accounts_current_schema.txt accounts_schema.txt analyses ci_profiles.sh claimable_balances_schema.txt config_settings_schema.txt contract_code_schema.txt contract_data_schema.txt country_code_schema.txt dbt_packages dbt_project.yml docker enriched_history_operations_schema.txt example.env gha-creds-8860b0d2aff83fdd.json history_assets_schema.txt history_assets_staging_schema.txt history_contract_events_schema.txt history_effects_schema.txt history_ledgers_schema.txt history_operations_schema.txt history_operations_temp_schema.txt history_trades_schema.txt history_transactions_schema.txt jenkins_lint_and_test.sh logs macros models packages.yml pre-commit profiles.yml requirements.txt seeds setup.sh snapshots target tests update_public_schema.sh base fee. The minimum base fee is 100 stroops
```

I think the `*` is causing weird things to happen, want to test to see if CI passes.

### Known limitations

[TODO or N/A]
