### PR TITLE
Limit window to test eho reconciliation

### DIFF
--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -19,11 +19,13 @@ WITH find_missing AS (
     -- Scan only the last 24 hours of data. Alert runs intraday so failures
     -- are caught and resolved quickly.
     AND TIMESTAMP(op.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 1 DAY )
+    AND TIMESTAMP(op.batch_run_date) < TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 1 HOUR )
 ),
 find_max_batch AS (
   SELECT MAX(batch_run_date) AS max_batch
   FROM {{ ref('stg_history_operations') }}
   WHERE TIMESTAMP(batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 1 DAY )
+    AND TIMESTAMP(batch_run_date) < TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 1 HOUR )
 )
 SELECT batch_run_date,
     batch_id,


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

This PR shortens window to test re-conciliation of history_operations table and enriched_history_operation table.

history_operations is updated at a faster cadence (10 min) as compared to enriched_history_operations (30 min) . Therefore, to not be false alerted, the reconciliation test will be done for slightly older data - last 24 hours - last 1 hour.

### Why

Explained above, we were getting false alarms from this singular test.

### Known limitations

NA
