### PR TITLE
Run singular tests conditionally

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -29,6 +29,7 @@ vars:
     exclude_packages: ["elementary"]
 
   airflow_start_timestamp: "{{ env_var('AIRFLOW_START_TIMESTAMP', '2000-01-01') }}"
+  is_singular_airflow_task: "{{ env_var('IS_SINGULAR_AIRFLOW_TASK', 'false') }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/tests/anomaly_detection_trade_count.sql
+++ b/tests/anomaly_detection_trade_count.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_count.sql
+++ b/tests/anomaly_detection_trade_count.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="warn"
     , tags=["singular_test"]

--- a/tests/anomaly_detection_trade_count.sql
+++ b/tests/anomaly_detection_trade_count.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_count.sql
+++ b/tests/anomaly_detection_trade_count.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_count.sql
+++ b/tests/anomaly_detection_trade_count.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_volume.sql
+++ b/tests/anomaly_detection_trade_volume.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_volume.sql
+++ b/tests/anomaly_detection_trade_volume.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="warn"
     , tags=["singular_test"]

--- a/tests/anomaly_detection_trade_volume.sql
+++ b/tests/anomaly_detection_trade_volume.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_volume.sql
+++ b/tests/anomaly_detection_trade_volume.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/anomaly_detection_trade_volume.sql
+++ b/tests/anomaly_detection_trade_volume.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/bucketlist_db_size_check.sql
+++ b/tests/bucketlist_db_size_check.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/bucketlist_db_size_check.sql
+++ b/tests/bucketlist_db_size_check.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/bucketlist_db_size_check.sql
+++ b/tests/bucketlist_db_size_check.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="error"
     , tags=["singular_test"]

--- a/tests/bucketlist_db_size_check.sql
+++ b/tests/bucketlist_db_size_check.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/bucketlist_db_size_check.sql
+++ b/tests/bucketlist_db_size_check.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -2,7 +2,7 @@
     severity="error"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -2,7 +2,7 @@
     severity="error"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="error"
     , tags=["singular_test"]

--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -2,7 +2,7 @@
     severity="error"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -2,6 +2,7 @@
     severity="error"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = ('{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = ({{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="warn"
     , tags=["singular_test"]

--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = ({{ var("is_singular_airflow_task") }} == "true")
+    , enabled=var("is_singular_airflow_task") == "true"
     )
 }}
 

--- a/tests/ledger_sequence_increment.sql
+++ b/tests/ledger_sequence_increment.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="warn"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = ('{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/num_txns_and_ops.sql
+++ b/tests/num_txns_and_ops.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/num_txns_and_ops.sql
+++ b/tests/num_txns_and_ops.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/num_txns_and_ops.sql
+++ b/tests/num_txns_and_ops.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="error"
     , tags=["singular_test"]

--- a/tests/num_txns_and_ops.sql
+++ b/tests/num_txns_and_ops.sql
@@ -1,6 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 

--- a/tests/num_txns_and_ops.sql
+++ b/tests/num_txns_and_ops.sql
@@ -1,7 +1,7 @@
 {{ config(
     severity="error"
     , tags=["singular_test"]
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/sorobon_surge_pricing_check.sql
+++ b/tests/sorobon_surge_pricing_check.sql
@@ -2,7 +2,7 @@
     severity="warn"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
+    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
     )
 }}
 

--- a/tests/sorobon_surge_pricing_check.sql
+++ b/tests/sorobon_surge_pricing_check.sql
@@ -2,7 +2,7 @@
     severity="warn"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
     )
 }}
 

--- a/tests/sorobon_surge_pricing_check.sql
+++ b/tests/sorobon_surge_pricing_check.sql
@@ -1,3 +1,5 @@
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
 {{ config(
     severity="warn"
     , tags=["singular_test"]

--- a/tests/sorobon_surge_pricing_check.sql
+++ b/tests/sorobon_surge_pricing_check.sql
@@ -2,7 +2,7 @@
     severity="warn"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
-    , enabled = (target.name == "prod" and '{{ var("is_singular_airflow_task") }}' == "true")
+    , enabled = (target.name == "prod" and {{ var("is_singular_airflow_task") }} == "true")
     )
 }}
 

--- a/tests/sorobon_surge_pricing_check.sql
+++ b/tests/sorobon_surge_pricing_check.sql
@@ -2,6 +2,7 @@
     severity="warn"
     , tags=["singular_test"]
     , meta={"alert_suppression_interval": 24}
+    , enabled = (target.name == "prod" and is_singular_airflow_task == "true")
     )
 }}
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

This PR adds config in singular tests to be enabled only in prod environment and when variable `is_singular_airflow_task` setup. 

### Why

It is a [known problem](https://discourse.getdbt.com/t/singular-test-how-to-skip-testing-all-models-inside-a-join/14500) that singular tests run whenever `dbt build` command is executed. Even with adding `--exclude singular_test` argument, dbt does not stop running these tests. Ideally we want singular tests to be run only as part of `dbt_singular_tests airflow task`.

The other option was to:
- Run `dbt run` and then `dbt test --exclude singular_test`. However, that will create data and then run tests , which [introduces risk of bad data quality](https://popsql.com/learn-dbt/dbt-build#comparing-dbt-build-vs-run).

### Testing

[Enriched_base_table_task](https://1e0b8e0c0615428ebb2815c5af8fbc72-dot-us-central1.composer.googleusercontent.com/log?dag_id=dbt_enriched_base_tables&task_id=dbt_build_enriched_history_operations_with_exclude&execution_date=2024-09-18T18%3A00%3A00%2B00%3A00) does not run any singular test with this PR

[dbt_singular_test_task](https://1e0b8e0c0615428ebb2815c5af8fbc72-dot-us-central1.composer.googleusercontent.com/log?dag_id=dbt_singular_tests&task_id=dbt_test_singular_test&execution_date=2024-09-18T18%3A00%3A00%2B00%3A00) runs only `ledger_sequence_increment` test since that enabled for test environment. In prod env, all singular test should run okay
