### PR TITLE
Add recency tag and conditionally enable recency tests

### DIFF
--- a/.github/workflows/project_evaluator_ci.yml
+++ b/.github/workflows/project_evaluator_ci.yml
@@ -15,6 +15,7 @@ env:
   DBT_JOB_TIMEOUT: 300
   DBT_THREADS: 1
   DBT_JOB_RETRIES: 1
+  IS_RECENCY_AIRFLOW_TASK: "false"
 
 jobs:
   dbt-project-evaluator:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,6 +30,7 @@ vars:
 
   airflow_start_timestamp: "{{ env_var('AIRFLOW_START_TIMESTAMP', '2000-01-01') }}"
   is_singular_airflow_task: "{{ env_var('IS_SINGULAR_AIRFLOW_TASK', 'false') }}"
+  is_recency_airflow_task: "{{ env_var('IS_RECENCY_AIRFLOW_TASK', 'false') }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -30,7 +30,6 @@ vars:
 
   airflow_start_timestamp: "{{ env_var('AIRFLOW_START_TIMESTAMP', '2000-01-01') }}"
   is_singular_airflow_task: "{{ env_var('IS_SINGULAR_AIRFLOW_TASK', 'false') }}"
-  is_recency_airflow_task: "{{ env_var('IS_RECENCY_AIRFLOW_TASK', 'false') }}"
 
 # Configuring models
 # Full documentation: https://docs.getdbt.com/docs/configuring-models

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -5,6 +5,7 @@ models:
     description: Aggregate table for the history operations
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -5,6 +5,7 @@ models:
     description: Aggregate table for the history operations, taking only the soroban operations
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/enriched_history/enriched_history_operations_soroban.yml
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/fee_stats_agg.yml
+++ b/models/marts/fee_stats_agg.yml
@@ -10,7 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/fee_stats_agg.yml
+++ b/models/marts/fee_stats_agg.yml
@@ -10,7 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/fee_stats_agg.yml
+++ b/models/marts/fee_stats_agg.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("fee_stats") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: day
           field: cast(day_agg as timestamp)
           interval: 2

--- a/models/marts/fee_stats_agg.yml
+++ b/models/marts/fee_stats_agg.yml
@@ -10,6 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("history_assets") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: day
           field: cast(batch_run_date as timestamp)
           interval: 2

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -10,7 +10,7 @@ models:
           field: cast(batch_run_date as timestamp)
           interval: 2
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -10,6 +10,7 @@ models:
           field: cast(batch_run_date as timestamp)
           interval: 2
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -10,7 +10,7 @@ models:
           field: cast(batch_run_date as timestamp)
           interval: 2
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("account_signers_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("accounts_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("claimable_balances_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_code_current.yml
+++ b/models/marts/ledger_current_state/contract_code_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 7
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_code_current.yml
+++ b/models/marts/ledger_current_state/contract_code_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 7
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_code_current.yml
+++ b/models/marts/ledger_current_state/contract_code_current.yml
@@ -5,10 +5,12 @@ models:
     description: '{{ doc("contract_code_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: day
           field: closed_at
           interval: 7
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("contract_data_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("liquidity_pools_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 24
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 24
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 24
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("offers_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("trust_lines_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -10,6 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("ttl_current") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: closed_at
           interval: 12

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -10,7 +10,7 @@ models:
           field: closed_at
           interval: 12
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/trade_agg.yml
+++ b/models/marts/trade_agg.yml
@@ -5,6 +5,7 @@ models:
     description: '{{ doc("trade_agg") }}'
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: day
           field: cast(day_agg as timestamp)
           interval: 2

--- a/models/marts/trade_agg.yml
+++ b/models/marts/trade_agg.yml
@@ -10,7 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
-            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
+            enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/trade_agg.yml
+++ b/models/marts/trade_agg.yml
@@ -10,7 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
-            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
+            enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."

--- a/models/marts/trade_agg.yml
+++ b/models/marts/trade_agg.yml
@@ -10,6 +10,7 @@ models:
           field: cast(day_agg as timestamp)
           interval: 2
           config:
+            enabled: (target.name == "ci" or var("is_recency_airflow_task") == "true")
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

We want to run recency tests asynchronously to building DBT models. This PR:
- Adds `recency` tag to all recency tests
- Conditionally enable recency tests when target is `ci` (to find test coverage accurately) or when the env variable `IS_RECENCY_AIRFLOW_TASK` is set to true. This env var is set to true only in `dbt_recency_test` dag. See https://github.com/stellar/stellar-etl-airflow/pull/500 

### Why

The recency tests cause alert fatigue since they run with every model build. We do not need to run them so frequently.
Also, recency tests creates issue in backfilling old tasks if newest task is failing.

### Known limitations

None
