### PR TITLE
Pick latest record when creating stg_history_assets

### DIFF
--- a/models/staging/stg_history_assets.sql
+++ b/models/staging/stg_history_assets.sql
@@ -10,7 +10,7 @@ with
         select
             *
             , row_number() over (
-                partition by asset_id order by batch_run_date asc
+                partition by asset_id order by batch_run_date desc
             ) as dedup_oldest_asset
         from {{ source('crypto_stellar', 'history_assets_staging') }}
     )


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to release/* , feature/* or patch/* .
</details>

### What

This PR updates SQL query for view stg_history_assets such that it picks latest record for a given asset id instead of oldest one.

### Why

Fetching old record does not give new picture of a given asset, also a stale closed_at date.

### Known limitations

[TODO or N/A]
