### PR TITLE
Untag staging and intermediate models

### DIFF
--- a/models/intermediate/trades/int_trade_agg_day.sql
+++ b/models/intermediate/trades/int_trade_agg_day.sql
@@ -1,6 +1,5 @@
 {{ config(
-    tags = ["trade_agg"]
-    , cluster_by =["asset_a", "asset_b"]
+    cluster_by =["asset_a", "asset_b"]
     )
 }}
 

--- a/models/intermediate/trades/int_trade_agg_month.sql
+++ b/models/intermediate/trades/int_trade_agg_month.sql
@@ -1,6 +1,5 @@
 {{ config(
-    tags = ["trade_agg"]
-    , cluster_by =["asset_a", "asset_b"]
+    cluster_by =["asset_a", "asset_b"]
     )
 }}
 

--- a/models/intermediate/trades/int_trade_agg_week.sql
+++ b/models/intermediate/trades/int_trade_agg_week.sql
@@ -1,6 +1,5 @@
 {{ config(
-    tags = ["trade_agg"]
-    , cluster_by =["asset_a", "asset_b"]
+    cluster_by =["asset_a", "asset_b"]
     )
 }}
 

--- a/models/intermediate/trades/int_trade_agg_year.sql
+++ b/models/intermediate/trades/int_trade_agg_year.sql
@@ -1,6 +1,5 @@
 {{ config(
-    tags = ["trade_agg"]
-    , cluster_by =["asset_a", "asset_b"]
+    cluster_by =["asset_a", "asset_b"]
     )
 }}
 

--- a/models/staging/stg_account_signers.sql
+++ b/models/staging/stg_account_signers.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_account_signers.sql
+++ b/models/staging/stg_account_signers.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_accounts.sql
+++ b/models/staging/stg_accounts.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_accounts.sql
+++ b/models/staging/stg_accounts.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_claimable_balances.sql
+++ b/models/staging/stg_claimable_balances.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_config_settings.sql
+++ b/models/staging/stg_config_settings.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_config_settings.sql
+++ b/models/staging/stg_config_settings.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_contract_code.sql
+++ b/models/staging/stg_contract_code.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_contract_code.sql
+++ b/models/staging/stg_contract_code.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_contract_data.sql
+++ b/models/staging/stg_contract_data.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_contract_data.sql
+++ b/models/staging/stg_contract_data.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_history_assets.sql
+++ b/models/staging/stg_history_assets.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 /* This query prepares the assets of each load for deduplication,
 in order to guarantee a new asset won't be loaded twice */
 with

--- a/models/staging/stg_history_assets.sql
+++ b/models/staging/stg_history_assets.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 /* This query prepares the assets of each load for deduplication,

--- a/models/staging/stg_history_effects.sql
+++ b/models/staging/stg_history_effects.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_history_effects.sql
+++ b/models/staging/stg_history_effects.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_history_ledgers.sql
+++ b/models/staging/stg_history_ledgers.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_history_ledgers.sql
+++ b/models/staging/stg_history_ledgers.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_history_operations.sql
+++ b/models/staging/stg_history_operations.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_history_operations.sql
+++ b/models/staging/stg_history_operations.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_history_trades.sql
+++ b/models/staging/stg_history_trades.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_history_trades.sql
+++ b/models/staging/stg_history_trades.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_history_transactions.sql
+++ b/models/staging/stg_history_transactions.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_history_transactions.sql
+++ b/models/staging/stg_history_transactions.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_liquidity_pools.sql
+++ b/models/staging/stg_liquidity_pools.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_offers.sql
+++ b/models/staging/stg_offers.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_offers.sql
+++ b/models/staging/stg_offers.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_trust_lines.sql
+++ b/models/staging/stg_trust_lines.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_trust_lines.sql
+++ b/models/staging/stg_trust_lines.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with

--- a/models/staging/stg_ttl.sql
+++ b/models/staging/stg_ttl.sql
@@ -1,6 +1,3 @@
-{{ config()
-}}
-
 with
     raw_table as (
         select *

--- a/models/staging/stg_ttl.sql
+++ b/models/staging/stg_ttl.sql
@@ -1,6 +1,4 @@
-{{ config(
-    tags = ["enriched_history_operations"]
-    )
+{{ config()
 }}
 
 with


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

Addresses https://stellarorg.atlassian.net/browse/HUBBLE-576

Untags staging and intermediate models so that the models aren't unnecessarily built based on tags.

### Why

Airflow executes dbt models according to tags. Some upstream models were tagged unnecessarily and rebuilt every dbt run. (ie, `enriched_history_operations`) this was causing dbt tests to fail if there were data delays, causing noisy alerts.

This change pushes model dependency management back into dbt. Models should be rebuilt using `dbt --select +tag:<tag>`. This will ensure models are only built when the downstream mart model executes, reducing noise and test execution.

### Known limitations

This PR must be released with corresponding Airflow changes to introduce `+` node selection to dbt model execution commands. If we are pushing dependency management into dbt, the command must rebuild dependent models.