### PR TITLE
Exclude public models from private model execution

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -36,7 +36,7 @@ vars:
 models:
   stellar_dbt_public:
     +tags: "public"
-    
+
     staging:
       +materialized: view # how the staging models will be materialized
     intermediate:
@@ -81,5 +81,7 @@ seeds:
       +enabled: false
 
 tests:
+  stellar_dbt_public:
+    +tags: "public"
   dbt_project_evaluator:
     +severity: "{{ env_var('DBT_PROJECT_EVALUATOR_SEVERITY', 'error') }}"

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,6 +35,8 @@ vars:
 # Full documentation: https://docs.getdbt.com/docs/configuring-models
 models:
   stellar_dbt_public:
+    +tags: "public"
+    
     staging:
       +materialized: view # how the staging models will be materialized
     intermediate:

--- a/models/marts/enriched_history/enriched_history_operations.yml
+++ b/models/marts/enriched_history/enriched_history_operations.yml
@@ -558,7 +558,7 @@ models:
               date_column_name: "closed_at"
               greater_than_equal_to: "2 day"
           - dbt_utils.expression_is_true:
-              expression: "<= 21"
+              expression: "<= 22"
               meta:
                 description: "Test to check for the correct protocol. Will update after P21 vote."
 


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

Adding a project level tag, `public` to stellar-dbt-public.

Protocol 22 was also deployed to testnet so adjusting the `protocol_version` test to allow for `>=22` versions. 

### Why

We are reorganizing how we schedule and orchestrate dbt models. The new changes were at risk for causing race conditions unless we built `stellar-dbt-public` models apart from the private repo.

### Known limitations

[TODO or N/A]
