### PR TITLE
Adjust recency tests, tag appropriately

### DIFF
--- a/models/marts/ledger_current_state/account_signers_current.yml
+++ b/models/marts/ledger_current_state/account_signers_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/accounts_current.yml
+++ b/models/marts/ledger_current_state/accounts_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/claimable_balances_current.yml
+++ b/models/marts/ledger_current_state/claimable_balances_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 48 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/contract_code_current.yml
+++ b/models/marts/ledger_current_state/contract_code_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: day
           field: closed_at
-          interval: 7
+          interval: '{{ 7 if target.name == "prod" else 14 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/contract_data_current.yml
+++ b/models/marts/ledger_current_state/contract_data_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/liquidity_pools_current.yml
+++ b/models/marts/ledger_current_state/liquidity_pools_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 24
+          interval: '{{ 24 if target.name == "prod" else 336 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/offers_current.yml
+++ b/models/marts/ledger_current_state/offers_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/trust_lines_current.yml
+++ b/models/marts/ledger_current_state/trust_lines_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/marts/ledger_current_state/ttl_current.yml
+++ b/models/marts/ledger_current_state/ttl_current.yml
@@ -8,7 +8,7 @@ models:
           tags: [recency]
           datepart: hour
           field: closed_at
-          interval: 12
+          interval: '{{ 12 if target.name == "prod" else 24 }}'
           config:
             enabled: '{{ target.name == "ci" or env_var("IS_RECENCY_AIRFLOW_TASK") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/staging/stg_account_signers.yml
+++ b/models/staging/stg_account_signers.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_account_signers
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_accounts.yml
+++ b/models/staging/stg_accounts.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_accounts
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_claimable_balances.yml
+++ b/models/staging/stg_claimable_balances.yml
@@ -4,9 +4,10 @@ models:
   - name: stg_claimable_balances
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
-          interval: '{{ 1 if target.name == "prod" else 24 }}'
+          interval: '{{ 1 if target.name == "prod" else 48 }}'
           config:
             enabled: '{{ target.name != "jenkins" }}'
           meta:

--- a/models/staging/stg_contract_data.yml
+++ b/models/staging/stg_contract_data.yml
@@ -4,9 +4,10 @@ models:
   - name: stg_contract_data
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
-          interval: '{{ 1 if target.name == "prod" else 24 }}'
+          interval: '{{ 1 if target.name == "prod" else 48 }}'
           config:
             enabled: '{{ target.name != "jenkins" }}'
           meta:

--- a/models/staging/stg_history_assets.yml
+++ b/models/staging/stg_history_assets.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_assets
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 3 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_effects.yml
+++ b/models/staging/stg_history_effects.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_effects
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_ledgers.yml
+++ b/models/staging/stg_history_ledgers.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_ledgers
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_operations.yml
+++ b/models/staging/stg_history_operations.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_operations
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_trades.yml
+++ b/models/staging/stg_history_trades.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_trades
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(ledger_closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_transactions.yml
+++ b/models/staging/stg_history_transactions.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_history_transactions
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_liquidity_pools.yml
+++ b/models/staging/stg_liquidity_pools.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_liquidity_pools
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 336}}'

--- a/models/staging/stg_offers.yml
+++ b/models/staging/stg_offers.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_offers
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_trust_lines.yml
+++ b/models/staging/stg_trust_lines.yml
@@ -4,6 +4,7 @@ models:
   - name: stg_trust_lines
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_ttl.yml
+++ b/models/staging/stg_ttl.yml
@@ -4,9 +4,10 @@ models:
   - name: stg_ttl
     tests:
       - dbt_utils.recency:
+          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
-          interval: '{{ 1 if target.name == "prod" else 24 }}'
+          interval: '{{ 1 if target.name == "prod" else 48 }}'
           config:
             enabled: '{{ target.name != "jenkins" }}'
           meta:


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

Adjust recency tests for source data and `_current` state tables.

The following changes were applied: 
- add a tag to `stg_*` models, called "recency". This aligns with our target models
- Increased the recency test range to 24 hours for `_current` tables in testnet env
- increased the recency test range to 48 hours for `claimable_balances` in pubnet 

### Why

Over the break, many tests were noisy due to lack of activity in testnet and mainnet. The testnet intervals were adjusted so that we aren't alerted as frequently on less used features (claimable balances, liquidity pools)

The recency tests for the source tables also weren't tagged appropriately, meaning they were missed from our recency dag. Added in case we need summarized data for all table freshness.

### Known limitations

[TODO or N/A]
