### PR TITLE
Revert recency tags from source only

### DIFF
--- a/models/staging/stg_account_signers.yml
+++ b/models/staging/stg_account_signers.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_account_signers
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_accounts.yml
+++ b/models/staging/stg_accounts.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_accounts
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_claimable_balances.yml
+++ b/models/staging/stg_claimable_balances.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_claimable_balances
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 48 }}'

--- a/models/staging/stg_contract_data.yml
+++ b/models/staging/stg_contract_data.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_contract_data
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 48 }}'

--- a/models/staging/stg_history_assets.yml
+++ b/models/staging/stg_history_assets.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_assets
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 3 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_effects.yml
+++ b/models/staging/stg_history_effects.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_effects
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_ledgers.yml
+++ b/models/staging/stg_history_ledgers.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_ledgers
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_operations.yml
+++ b/models/staging/stg_history_operations.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_operations
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_trades.yml
+++ b/models/staging/stg_history_trades.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_trades
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(ledger_closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_history_transactions.yml
+++ b/models/staging/stg_history_transactions.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_history_transactions
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_liquidity_pools.yml
+++ b/models/staging/stg_liquidity_pools.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_liquidity_pools
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 336}}'

--- a/models/staging/stg_offers.yml
+++ b/models/staging/stg_offers.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_offers
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_trust_lines.yml
+++ b/models/staging/stg_trust_lines.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_trust_lines
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 24 }}'

--- a/models/staging/stg_ttl.yml
+++ b/models/staging/stg_ttl.yml
@@ -4,7 +4,6 @@ models:
   - name: stg_ttl
     tests:
       - dbt_utils.recency:
-          tags: [recency]
           datepart: hour
           field: cast(closed_at as timestamp)
           interval: '{{ 1 if target.name == "prod" else 48 }}'


### PR DESCRIPTION
Reverting `recency` tag from source models because of unintentional consequences (see: [comment](https://github.com/stellar/stellar-dbt-public/pull/125#discussion_r1904273563)) 

We don't want to trigger staging recency checks apart from model builds. I decided not to revert the entire PR because we want to preserve the config changes to the recency intervals themselves.

This PR only removes the tag `recency` from staging models.