### PR TITLE
ledger current state marts join removal

### DIFF
--- a/models/marts/ledger_current_state/account_signers_current.sql
+++ b/models/marts/ledger_current_state/account_signers_current.sql
@@ -23,7 +23,7 @@ with
             , s.weight
             , s.sponsor
             , s.last_modified_ledger
-            , l.closed_at
+            , s.closed_at
             , s.ledger_entry_change
             , s.deleted
             -- table only has natural keys, creating a primary key
@@ -36,13 +36,11 @@ with
                     order by s.last_modified_ledger desc, s.ledger_entry_change desc
                 ) as row_nr
         from {{ ref('stg_account_signers') }} as s
-        join {{ ref('stg_history_ledgers') }} as l
-            on s.last_modified_ledger = l.sequence
 
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(s.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
+                timestamp(s.batch_run_date) >= timestamp_sub('{{ dbt_airflow_macros.ts(timezone=none) }}', interval 7 day)
         {% endif %}
     )
 select

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -36,7 +36,7 @@ with
             , a.threshold_high
             , a.last_modified_ledger
             , a.ledger_entry_change
-            , l.closed_at
+            , a.closed_at
             , a.deleted
             , a.sponsor
             , a.sequence_ledger
@@ -51,13 +51,11 @@ with
                 )
                 as row_nr
         from {{ ref('stg_accounts') }} as a
-        join {{ ref('stg_history_ledgers') }} as l
-            on a.last_modified_ledger = l.sequence
 
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(a.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
+                timestamp(a.batch_run_date) >= timestamp_sub('{{ dbt_airflow_macros.ts(timezone=none) }}', interval 7 day)
         {% endif %}
     )
 

--- a/models/marts/ledger_current_state/liquidity_pools_current.sql
+++ b/models/marts/ledger_current_state/liquidity_pools_current.sql
@@ -37,7 +37,7 @@ with
             , lp.asset_b_amount
             , lp.last_modified_ledger
             , lp.ledger_entry_change
-            , l.closed_at
+            , lp.closed_at
             , lp.deleted
             , lp.batch_run_date
             , row_number()
@@ -46,13 +46,11 @@ with
                     order by lp.last_modified_ledger desc, lp.ledger_entry_change desc
                 ) as row_nr
         from {{ ref('stg_liquidity_pools') }} as lp
-        join {{ ref('stg_history_ledgers') }} as l
-            on lp.last_modified_ledger = l.sequence
 
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(lp.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
+                timestamp(lp.batch_run_date) >= timestamp_sub('{{ dbt_airflow_macros.ts(timezone=none) }}', interval 7 day)
         {% endif %}
 
     )

--- a/models/marts/ledger_current_state/offers_current.sql
+++ b/models/marts/ledger_current_state/offers_current.sql
@@ -28,7 +28,7 @@ with
             , o.price
             , o.flags
             , o.last_modified_ledger
-            , l.closed_at
+            , o.closed_at
             , o.ledger_entry_change
             , o.deleted
             , o.sponsor
@@ -39,13 +39,11 @@ with
                     order by o.last_modified_ledger desc, o.ledger_entry_change desc
                 ) as row_nr
         from {{ ref('stg_offers') }} as o
-        join {{ ref('stg_history_ledgers') }} as l
-            on o.last_modified_ledger = l.sequence
 
         {% if is_incremental() %}
             -- limit the number of partitions fetched
             where
-                TIMESTAMP(o.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
+                timestamp(o.batch_run_date) >= timestamp_sub('{{ dbt_airflow_macros.ts(timezone=none) }}', interval 7 day)
         {% endif %}
 
     )

--- a/models/marts/ledger_current_state/trust_lines_current.sql
+++ b/models/marts/ledger_current_state/trust_lines_current.sql
@@ -31,7 +31,7 @@ with
             , tl.trust_line_limit
             , tl.last_modified_ledger
             , tl.ledger_entry_change
-            , l.closed_at
+            , tl.closed_at
             , tl.deleted
             -- table only has natural keys, creating a primary key
             , concat(tl.account_id, '-', tl.asset_code, '-', tl.asset_issuer, '-', tl.liquidity_pool_id
@@ -43,13 +43,11 @@ with
                     order by tl.last_modified_ledger desc, tl.ledger_entry_change desc
                 ) as row_nr
         from {{ ref('stg_trust_lines') }} as tl
-        join {{ ref('stg_history_ledgers') }} as l
-            on tl.last_modified_ledger = l.sequence
 
         {% if is_incremental() %}
             -- limit the number of partitions fetched incrementally
             where
-                TIMESTAMP(tl.batch_run_date) >= TIMESTAMP_SUB('{{ dbt_airflow_macros.ts(timezone=none) }}', INTERVAL 7 day )
+                timestamp(tl.batch_run_date) >= timestamp_sub('{{ dbt_airflow_macros.ts(timezone=none) }}', interval 7 day)
         {% endif %}
 
     )


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

Removed unnecessary joins to `history_ledgers` table in 5 ledger current state models by using `closed_at` timestamp directly from staging tables.

**Updated models:**
- `accounts_current.sql`
- `account_signers_current.sql` 
- `liquidity_pools_current.sql`
- `offers_current.sql`
- `trust_lines_current.sql`

### Why

Performance optimization - state tables already contain `closed_at` timestamps, making the join to `history_ledgers` redundant. This reduces query complexity and improves performance while maintaining identical output.

### Known limitations

N/A