### PR TITLE
Remove force_enable setting from .sqlfluff

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -219,7 +219,6 @@ ignore_words_regex = None
 prefer_quoted_identifiers = False
 ignore_words = None
 ignore_words_regex = None
-force_enable = False
 
 [sqlfluff:rules:layout.long_lines]
 # Line length


### PR DESCRIPTION
Remove force_enable setting from .sqlfluff configuration

<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

[TODO: Short statement about what is changing.]

### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
