### PR TITLE
Ignore time component in reflector models

### DIFF
--- a/models/intermediate/reflector_prices/int_reflector_prices__cex.yml
+++ b/models/intermediate/reflector_prices/int_reflector_prices__cex.yml
@@ -9,6 +9,7 @@ models:
           datepart: day
           field: day
           interval: 2
+          ignore_time_component: true
           config:
             enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/intermediate/reflector_prices/int_reflector_prices__fex.yml
+++ b/models/intermediate/reflector_prices/int_reflector_prices__fex.yml
@@ -9,6 +9,7 @@ models:
           datepart: day
           field: day
           interval: 2
+          ignore_time_component: true
           config:
             enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'

--- a/models/intermediate/reflector_prices/int_reflector_prices__sdex.yml
+++ b/models/intermediate/reflector_prices/int_reflector_prices__sdex.yml
@@ -9,6 +9,7 @@ models:
           datepart: day
           field: day
           interval: 2
+          ignore_time_component: true
           config:
             enabled: '{{ target.name == "ci" or var("is_recency_airflow_task") == "true" }}'
             severity: '{{ "error" if target.name == "prod" else "warn" }}'


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

This PR resolves recency test failures with reflector models.

Logs

```
[2025-11-24 15:32:25.085377+00:00] {pod_manager.py:477} INFO - [base] 15:32:25  Failure in test dbt_utils_recency_int_reflector_prices__cex_day__day__2 (models/intermediate/reflector_prices/int_reflector_prices__cex.yml)
[2025-11-24 15:32:25.085902+00:00] {pod_manager.py:477} INFO - [base] 15:32:25    Database Error in test dbt_utils_recency_int_reflector_prices__cex_day__day__2 (models/intermediate/reflector_prices/int_reflector_prices__cex.yml)
[2025-11-24 15:32:25.086223+00:00] {pod_manager.py:477} INFO - [base]   No matching signature for operator < for argument types: DATE, TIMESTAMP
[2025-11-24 15:32:25.086690+00:00] {pod_manager.py:477} INFO - [base]     Signature: T1 < T1
[2025-11-24 15:32:25.087048+00:00] {pod_manager.py:477} INFO - [base]       Unable to find common supertype for templated argument <T1>
[2025-11-24 15:32:25.087326+00:00] {pod_manager.py:477} INFO - [base]         Input types for <T1>: {DATE, TIMESTAMP} at [45:7]
[2025-11-24 15:32:25.087585+00:00] {pod_manager.py:477} INFO - [base]   compiled code at target/run/stellar_dbt_public/models/intermediate/reflector_prices/int_reflector_prices__cex.yml/dbt_utils_recency_int_reflector_prices__cex_day__day__2.sql
[2025-11-24 15:32:25.088002+00:00] {pod_manager.py:477} INFO - [base] 15:32:25
```

Adds ignore _time_component which will only compare day
### Why

[TODO: Why this change is being made. Include any context required to understand the why.]

### Known limitations

[TODO or N/A]
