### PR TITLE
Fix date filtering bug

### DIFF
--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -53,7 +53,7 @@ with
         inner join filtered_tl as ftl
             on
             timestamp(dt.day) >= timestamp_trunc(ftl.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(ftl.valid_to, day) or ftl.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(ftl.valid_to, day) or ftl.valid_to is null)
     )
 
     , all_lp as (
@@ -64,7 +64,7 @@ with
         inner join filtered_lp as flp
             on
             timestamp(dt.day) >= timestamp_trunc(flp.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(flp.valid_to, day) or flp.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(flp.valid_to, day) or flp.valid_to is null)
     )
 
     , joined as (

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -71,7 +71,7 @@ with
         inner join filtered_tl as tl
             on
             timestamp(dt.day) >= timestamp_trunc(tl.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(tl.valid_to, day) or tl.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(tl.valid_to, day) or tl.valid_to is null)
 
         union all
 
@@ -86,7 +86,7 @@ with
         inner join filtered_acc as acc
             on
             timestamp(dt.day) >= timestamp_trunc(acc.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(acc.valid_to, day) or acc.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(acc.valid_to, day) or acc.valid_to is null)
     )
 
 select

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -66,7 +66,7 @@ with
         inner join filtered_tl as tl
             on
             timestamp(dt.day) >= timestamp_trunc(tl.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(tl.valid_to, day) or tl.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(tl.valid_to, day) or tl.valid_to is null)
 
         union all
 
@@ -81,7 +81,7 @@ with
         inner join filtered_acc as acc
             on
             timestamp(dt.day) >= timestamp_trunc(acc.valid_from, day)
-            and (timestamp(date_add(dt.day, interval 1 day)) < timestamp_trunc(acc.valid_to, day) or acc.valid_to is null)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(acc.valid_to, day) or acc.valid_to is null)
     )
 
 select


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

Closes #185 
Update date filters on snapshot table so that `valid_from` and `valid_to` filters are truncated to the date (hour shouldn't matter)

The valid_to filter also needed an update to cutoff day + 1 since the operator is exclusive of the end date.

### Why

Market cap reports were lagging by a day for account balance changes. End of month reports do not reconcile rwa.xyz. Most notable with BENJI, which is missing ~$20M in market cap in Jan 2025.

### Known limitations

This is a temporary fix to make sure daily market caps reconcile with other systems. The long term fix should be updating the snapshots table to use date instead of timestamp for `valid_to` and `valid_from`