### PR TITLE
[#189] Add Soroban core metrics and config settings snapshot models

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -82,6 +82,8 @@ models:
 
 seeds:
   stellar_dbt_public:
+    config_setting_to_metrics_mapping:
+      +dataset: crypto_stellar_dbt
     dbt_project_evaluator_config:
       +dataset: dbt_project_evaluator
   dbt_project_evaluator:

--- a/models/docs/marts/soroban/config_settings_snapshot.md
+++ b/models/docs/marts/soroban/config_settings_snapshot.md
@@ -1,4 +1,4 @@
-[comment]: < Configuration Settings Snapshot -
+[comment]: < Configuration Settings Snapshot - >
 
 {% docs config_settings_snapshot %}
 

--- a/models/docs/marts/soroban/config_settings_snapshot.md
+++ b/models/docs/marts/soroban/config_settings_snapshot.md
@@ -1,0 +1,29 @@
+[comment]: < Configuration Settings Snapshot -
+
+{% docs config_settings_snapshot %}
+
+This table captures historical snapshots of various configuration settings from the Stellar network. It unpivots different metric values from the `config_settings` table and tracks their validity over time.
+
+Each metric represents a specific setting related to transaction limits, ledger constraints, fees, and other network parameters. The `valid_from` and `valid_to` timestamps help in identifying when each setting was active.
+
+The table is enriched with metric mapping data from the `config_setting_to_metrics_mapping` seed, providing core metric names, granularity levels, and human-readable display names for each config setting.
+
+{% enddocs %}
+
+{% docs config_setting_name %}
+
+The name of the configuration setting (metric) extracted from the source table. Each row represents a different setting tracked over time.
+
+{% enddocs %}
+
+{% docs setting_value %}
+
+The numeric value associated with the configuration setting. This value represents the active limit, fee, or constraint set by the network.
+
+{% enddocs %}
+
+{% docs is_current_setting %}
+
+Boolean flag indicating if the setting is currently in effect (`true` if `valid_to` is null).
+
+{% enddocs %}

--- a/models/docs/marts/soroban/soroban_core_metrics.md
+++ b/models/docs/marts/soroban/soroban_core_metrics.md
@@ -1,0 +1,21 @@
+[comment]: < Soroban Core Metrics -
+
+{% docs soroban_core_metrics %}
+
+Pre-parsed and flattened core_metrics contract events from Soroban. Each row represents a single metric emitted by a core_metrics diagnostic event, enabling efficient network utilization calculations without full table scans and JSON parsing of the raw `history_contract_events` table.
+
+This model extracts the metric key and value from the JSON-encoded topics and data fields of contract events where the first topic symbol is `core_metrics` and the event type is diagnostic (`type = 2`).
+
+{% enddocs %}
+
+{% docs metric_key %}
+
+The name of the core metric emitted by the Soroban contract event (e.g., cpu_insn, mem_byte, read_entry, write_entry, ledger_read_byte, ledger_write_byte, emit_event_byte).
+
+{% enddocs %}
+
+{% docs metric_value %}
+
+The numeric value of the core metric, representing resource consumption for the associated transaction.
+
+{% enddocs %}

--- a/models/marts/soroban/config_settings_snapshot.sql
+++ b/models/marts/soroban/config_settings_snapshot.sql
@@ -8,7 +8,7 @@
     )
 }}
 
-{% set columns = adapter.get_columns_in_relation(ref('stg_config_settings')) %}
+{% set columns = adapter.get_columns_in_relation(source('crypto_stellar', 'config_settings')) %}
 
 {% set excluded_cols = [
     'config_setting_id',
@@ -70,7 +70,7 @@ select
     , scd.is_current_setting
     , m.core_metric
     , m.grain
-    , m.is_resource_utilization_relevent
+    , m.is_resource_utilization_relevant
     , m.pretty_config_name
 from scd
 left join {{ ref('config_setting_to_metrics_mapping') }} as m

--- a/models/marts/soroban/config_settings_snapshot.sql
+++ b/models/marts/soroban/config_settings_snapshot.sql
@@ -1,0 +1,78 @@
+{% set meta_config = {
+    "tags": ["soroban", "network_stats"]
+} %}
+
+{{ config(
+    meta=meta_config,
+    **meta_config,
+    )
+}}
+
+{% set columns = adapter.get_columns_in_relation(ref('stg_config_settings')) %}
+
+{% set excluded_cols = [
+    'config_setting_id',
+    'contract_cost_params_cpu_insns',
+    'contract_cost_params_mem_bytes',
+    'deleted',
+    'batch_id',
+    'batch_run_date',
+    'batch_insert_ts',
+    'ledger_sequence',
+    'bucket_list_size_window',
+    'closed_at',
+    'airflow_start_ts'
+] %}
+
+{% set filtered_cols = [] %}
+{% for col in columns %}
+    {% if col.name not in excluded_cols %}
+        {% do filtered_cols.append(col) %}
+    {% endif %}
+{% endfor %}
+
+with
+    unpivoted as (
+
+        {% for metric in filtered_cols %}
+            select
+                '{{ metric.name }}' as metric
+                , {{ metric.name }} as val
+                , closed_at as valid_from
+            from {{ ref('stg_config_settings') }}
+            where {{ metric.name }} <> 0
+            group by 1, 2, 3
+            {% if not loop.last %}
+                union all
+            {% endif %}
+        {% endfor %}
+    )
+
+    , scd as (
+        select
+            *
+            , valid_to is null as is_current_setting
+        from (
+            select
+                metric as config_setting_name
+                , val as setting_value
+                , valid_from
+                , lead(valid_from) over (partition by metric order by valid_from) as valid_to
+            from unpivoted
+        )
+    )
+
+select
+    scd.config_setting_name
+    , scd.setting_value
+    , scd.valid_from
+    , scd.valid_to
+    , scd.is_current_setting
+    , m.core_metric
+    , m.grain
+    , m.is_resource_utilization_relevent
+    , m.pretty_config_name
+from scd
+left join {{ ref('config_setting_to_metrics_mapping') }} as m
+    on scd.config_setting_name = m.config_setting_description
+order by scd.config_setting_name, scd.valid_from

--- a/models/marts/soroban/config_settings_snapshot.yml
+++ b/models/marts/soroban/config_settings_snapshot.yml
@@ -46,7 +46,8 @@ models:
           Soroban network resource utilization ratios.
         tests:
           - accepted_values:
-              values: ['TRUE', 'FALSE']
+              values: [true, false]
+              quote: false
       - name: pretty_config_name
         description: >
           A human-readable display name for the config setting,

--- a/models/marts/soroban/config_settings_snapshot.yml
+++ b/models/marts/soroban/config_settings_snapshot.yml
@@ -1,0 +1,53 @@
+version: 2
+
+models:
+  - name: config_settings_snapshot
+    description: '{{ doc("config_settings_snapshot") }}'
+    tests:
+      - elementary.schema_changes:
+          tags: [schema_changes]
+          config:
+            severity: warn
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - config_setting_name
+            - valid_from
+          meta:
+            description: "Tests the uniqueness combination of: config_setting_name and valid_from."
+    columns:
+      - name: config_setting_name
+        description: '{{ doc("config_setting_name") }}'
+        tests:
+          - not_null
+      - name: setting_value
+        description: '{{ doc("setting_value") }}'
+        tests:
+          - not_null
+      - name: valid_from
+        description: '{{ doc("valid_from") }}'
+        tests:
+          - not_null
+      - name: valid_to
+        description: '{{ doc("valid_to") }}'
+      - name: is_current_setting
+        description: '{{ doc("is_current_setting") }}'
+      - name: core_metric
+        description: >
+          The core metric name that this config setting maps to
+          (e.g., cpu_insn, mem_byte, read_entry). Null if the setting
+          does not map to a core metric.
+      - name: grain
+        description: >
+          The granularity level of the config setting limit,
+          either 'ledger' or 'transaction'.
+      - name: is_resource_utilization_relevent
+        description: >
+          Whether this config setting is relevant for calculating
+          Soroban network resource utilization ratios.
+        tests:
+          - accepted_values:
+              values: ['TRUE', 'FALSE']
+      - name: pretty_config_name
+        description: >
+          A human-readable display name for the config setting,
+          suitable for dashboards and reporting.

--- a/models/marts/soroban/soroban_core_metrics.sql
+++ b/models/marts/soroban/soroban_core_metrics.sql
@@ -27,7 +27,7 @@ from {{ ref('stg_history_contract_events') }}
 where
     json_value(topics_decoded[0], '$.symbol') = 'core_metrics'
     and type = 2
-    and closed_at < timestamp(date('{{ var("batch_end_date") }}'))
+    and closed_at < timestamp_add(timestamp(date('{{ var("batch_end_date") }}')), interval 1 day)
 {% if is_incremental() %}
-    and closed_at >= timestamp(date('{{ var("batch_start_date") }}'))
+    and closed_at >= timestamp_sub(timestamp(date('{{ var("batch_start_date") }}')), interval 1 day)
 {% endif %}

--- a/models/marts/soroban/soroban_core_metrics.sql
+++ b/models/marts/soroban/soroban_core_metrics.sql
@@ -1,0 +1,33 @@
+{% set meta_config = {
+    "materialized": "incremental",
+    "unique_key": ["transaction_hash", "contract_id", "metric_key"],
+    "partition_by": {
+        "field": "closed_at"
+        , "data_type": "timestamp"
+        , "granularity": "day"},
+    "cluster_by": ["contract_id", "metric_key"],
+    "incremental_predicates": ["DBT_INTERNAL_DEST.closed_at >= timestamp_sub(timestamp(date('" ~ var('batch_start_date') ~ "')), interval 1 day)"],
+    "tags": ["soroban", "network_stats"]
+} %}
+
+{{ config(
+    meta=meta_config,
+    **meta_config,
+    )
+}}
+
+select
+    transaction_hash
+    , ledger_sequence
+    , closed_at
+    , contract_id
+    , safe_cast(json_value(topics_decoded[1], '$.symbol') as string) as metric_key
+    , safe_cast(json_value(data_decoded, '$.u64') as int64) as metric_value
+from {{ ref('stg_history_contract_events') }}
+where
+    json_value(topics_decoded[0], '$.symbol') = 'core_metrics'
+    and type = 2
+    and closed_at < timestamp(date('{{ var("batch_end_date") }}'))
+{% if is_incremental() %}
+    and closed_at >= timestamp(date('{{ var("batch_start_date") }}'))
+{% endif %}

--- a/models/marts/soroban/soroban_core_metrics.yml
+++ b/models/marts/soroban/soroban_core_metrics.yml
@@ -1,0 +1,38 @@
+version: 2
+
+models:
+  - name: soroban_core_metrics
+    description: '{{ doc("soroban_core_metrics") }}'
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - transaction_hash
+            - contract_id
+            - metric_key
+          meta:
+            description: "Tests the uniqueness combination of: transaction_hash, contract_id, and metric_key."
+    columns:
+      - name: transaction_hash
+        description: '{{ doc("transaction_hash") }}'
+        tests:
+          - not_null
+      - name: ledger_sequence
+        description: '{{ doc("ledger_sequence") }}'
+        tests:
+          - not_null
+      - name: closed_at
+        description: '{{ doc("closed_at") }}'
+        tests:
+          - not_null
+      - name: contract_id
+        description: '{{ doc("contract_id") }}'
+        tests:
+          - not_null
+      - name: metric_key
+        description: '{{ doc("metric_key") }}'
+        tests:
+          - not_null
+      - name: metric_value
+        description: '{{ doc("metric_value") }}'
+        tests:
+          - not_null

--- a/seeds/config_setting_to_metrics_mapping.csv
+++ b/seeds/config_setting_to_metrics_mapping.csv
@@ -1,4 +1,4 @@
-pretty_config_name,config_setting_description,core_metric,grain,is_resource_utilization_relevent,is_resource_fee_setting,is_public_on_dev_docs
+pretty_config_name,config_setting_description,core_metric,grain,is_resource_utilization_relevant,is_resource_fee_setting,is_public_on_dev_docs
 ,contract_max_size_bytes,,,FALSE,FALSE,FALSE
 ,ledger_max_instructions,cpu_insn,ledger,TRUE,FALSE,FALSE
 Max CPU instructions per txn,tx_max_instructions,cpu_insn,transaction,TRUE,FALSE,TRUE

--- a/seeds/config_setting_to_metrics_mapping.csv
+++ b/seeds/config_setting_to_metrics_mapping.csv
@@ -35,7 +35,7 @@ Persistent entry minimal/initial lifetime,min_persistent_ttl,,,FALSE,FALSE,TRUE
 30 days of rent for 1 KB of temporary storage,temp_rent_rate_denominator,,,FALSE,TRUE,TRUE
 ,max_entries_to_archive,,,TRUE,FALSE,FALSE
 ,bucket_list_size_window_sample_size,,,FALSE,FALSE,FALSE
-Eviction Scan Size ,eviction_scan_size,,,FALSE,FALSE,TRUE
+Eviction Scan Size,eviction_scan_size,,,FALSE,FALSE,TRUE
 ,starting_eviction_scan_level,,,FALSE,FALSE,FALSE
 Soroban txn per ledger,ledger_max_tx_count,transaction_hash,ledger,TRUE,FALSE,TRUE
 ,bucket_list_size_window,,,FALSE,FALSE,FALSE

--- a/seeds/config_setting_to_metrics_mapping.csv
+++ b/seeds/config_setting_to_metrics_mapping.csv
@@ -1,0 +1,41 @@
+pretty_config_name,config_setting_description,core_metric,grain,is_resource_utilization_relevent,is_resource_fee_setting,is_public_on_dev_docs
+,contract_max_size_bytes,,,FALSE,FALSE,FALSE
+,ledger_max_instructions,cpu_insn,ledger,TRUE,FALSE,FALSE
+Max CPU instructions per txn,tx_max_instructions,cpu_insn,transaction,TRUE,FALSE,TRUE
+"10,000 instructions",fee_rate_per_instructions_increment,,,FALSE,TRUE,TRUE
+Memory limit per txn,tx_memory_limit,mem_byte,transaction,TRUE,FALSE,TRUE
+,ledger_max_read_ledger_entries,read_entry,ledger,TRUE,FALSE,FALSE
+,ledger_max_read_bytes,ledger_read_byte,ledger,TRUE,FALSE,FALSE
+,ledger_max_write_ledger_entries,write_entry,ledger,TRUE,FALSE,FALSE
+Max write bytes per ledger,ledger_max_write_bytes,ledger_write_byte,ledger,TRUE,FALSE,TRUE
+Read ledger entries per txn,tx_max_read_ledger_entries,read_entry,transaction,TRUE,FALSE,TRUE
+Read bytes per txn,tx_max_read_bytes,ledger_read_byte,transaction,TRUE,FALSE,TRUE
+Write ledger entries per txn,tx_max_write_ledger_entries,write_entry,transaction,TRUE,FALSE,TRUE
+Write bytes per txn,tx_max_write_bytes,ledger_write_byte,transaction,TRUE,FALSE,TRUE
+Read 1 ledger entry,fee_read_ledger_entry,,,FALSE,TRUE,TRUE
+Write 1 ledger entry,fee_write_ledger_entry,,,FALSE,TRUE,TRUE
+Read 1KB from ledger,fee_read_1kb,,,FALSE,TRUE,TRUE
+,bucket_list_target_size_bytes,,,FALSE,FALSE,FALSE
+Write 1KB to ledger,write_fee_1kb_bucket_list_low,,,FALSE,TRUE,TRUE
+Write 1KB to ledger,write_fee_1kb_bucket_list_high,,,FALSE,TRUE,TRUE
+,bucket_list_write_fee_growth_factor,,,FALSE,FALSE,FALSE
+1KB of transaction size (history),fee_historical_1kb,,,FALSE,TRUE,TRUE
+Events+return value size bytes,tx_max_contract_events_size_bytes,emit_event_byte,transaction,TRUE,FALSE,TRUE
+1KB of Events/return value,fee_contract_events_1kb,,,FALSE,TRUE,TRUE
+Max txs size in bytes per ledger,ledger_max_txs_size_bytes,,,TRUE,FALSE,TRUE
+Transaction size,tx_max_size_bytes,,,TRUE,FALSE,TRUE
+1KB of transaction size (bandwidth),fee_tx_size_1kb,,,TRUE,TRUE,TRUE
+Individual ledger key size (contract storage key),contract_data_key_size_bytes,,,TRUE,FALSE,TRUE
+Individual ledger entry size (including Wasm entries),contract_data_entry_size_bytes,,,TRUE,FALSE,TRUE
+Max ledger entry expiration bump,max_entry_ttl,,,FALSE,FALSE,TRUE
+Temporary entry minimal/initial lifetime,min_temporary_ttl,,,FALSE,FALSE,TRUE
+Persistent entry minimal/initial lifetime,min_persistent_ttl,,,FALSE,FALSE,TRUE
+,auto_bump_ledgers,,,FALSE,FALSE,FALSE
+30 days of rent for 1 KB of persistent storage,persistent_rent_rate_denominator,,,FALSE,TRUE,TRUE
+30 days of rent for 1 KB of temporary storage,temp_rent_rate_denominator,,,FALSE,TRUE,TRUE
+,max_entries_to_archive,,,TRUE,FALSE,FALSE
+,bucket_list_size_window_sample_size,,,FALSE,FALSE,FALSE
+Eviction Scan Size ,eviction_scan_size,,,FALSE,FALSE,TRUE
+,starting_eviction_scan_level,,,FALSE,FALSE,FALSE
+Soroban txn per ledger,ledger_max_tx_count,transaction_hash,ledger,TRUE,FALSE,TRUE
+,bucket_list_size_window,,,FALSE,FALSE,FALSE


### PR DESCRIPTION
## Summary

- Adds `soroban_core_metrics` incremental model that pre-parses `core_metrics` diagnostic contract events, enabling efficient Soroban network utilization queries without full table scans and JSON parsing
- Adds `config_settings_snapshot` table model with SCD2 history of network config settings, enriched with metric mapping seed for utilization analysis
- Adds `config_setting_to_metrics_mapping` seed mapping config setting names to core metrics, grain, and utilization relevance

Closes #189

## Test plan

- [ ] Verify `soroban_core_metrics` incremental logic filters correctly by `batch_start_date`/`batch_end_date` with partition pruning
- [ ] Verify `config_settings_snapshot` correctly unpivots all config settings and applies SCD2 logic
- [ ] Verify seed join enriches config settings with `core_metric`, `grain`, `is_resource_utilization_relevent`, `pretty_config_name`
- [ ] Run `dbt test` to confirm uniqueness, not_null, and accepted_values constraints pass
- [ ] Validate output matches reference utilization query against production tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)