### PR TITLE
[645] Create amm tvl metrics (liquidity_pools_tvl) in tvl_agg

### DIFF
--- a/models/docs/marts/tvl/tvl_agg.md
+++ b/models/docs/marts/tvl/tvl_agg.md
@@ -12,6 +12,10 @@ The total value locked (TVL) denominated in raw asset value (token amounts) for 
 The total value locked (TVL) denominated in raw asset value (token amounts) for a given date. Aggregated across trustlines selling liabilities
 {% enddocs %}
 
+{% docs liquidity_pools_tvl %}
+The total value locked (TVL) denominated in raw asset value (token amounts) for a given date. Aggregated across liquidity pool balances (AMM).
+{% enddocs %}
+
 {% docs total_tvl %}
-The total value locked (TVL) denominated in raw asset value (token amounts) for a given date. Aggregated across relevant ledger entries (e.g., accounts, trustlines).
+The total value locked (TVL) denominated in raw asset value (token amounts) for a given date. Aggregated across relevant ledger entries (e.g., accounts, trustlines, liquidity pools).
 {% enddocs %}

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -33,21 +33,40 @@ with
         group by 1, 2, 3, 4
     )
 
+    , liquidity_pools_tvl as (
+        select
+            day
+            , asset_type
+            , asset_code
+            , asset_issuer
+            , sum(liquidity_pool_balance) as liquidity_pools_tvl
+        from {{ ref('asset_balances__daily_agg') }}
+        group by 1, 2, 3, 4
+    )
+
     , combined as (
         select
-            coalesce(a.day, t.day) as day
-            , coalesce(a.asset_type, t.asset_type) as asset_type
-            , coalesce(a.asset_code, t.asset_code) as asset_code
-            , coalesce(a.asset_issuer, t.asset_issuer) as asset_issuer
+            coalesce(a.day, t.day, l.day) as day
+            , coalesce(a.asset_type, t.asset_type, l.asset_type) as asset_type
+            , coalesce(a.asset_code, t.asset_code, l.asset_code) as asset_code
+            , coalesce(a.asset_issuer, t.asset_issuer, l.asset_issuer) as asset_issuer
             , coalesce(a.accounts_tvl, 0) as accounts_tvl
             , coalesce(t.trustlines_tvl, 0) as trustlines_tvl
-            , coalesce(a.accounts_tvl, 0) + coalesce(t.trustlines_tvl, 0) as total_tvl
+            , coalesce(l.liquidity_pools_tvl, 0) as liquidity_pools_tvl
+            , coalesce(a.accounts_tvl, 0)
+            + coalesce(t.trustlines_tvl, 0)
+            + coalesce(l.liquidity_pools_tvl, 0) as total_tvl
         from accounts_tvl as a
         full outer join trustlines_tvl as t
             on a.day = t.day
             and a.asset_type = t.asset_type
             and a.asset_code = t.asset_code
             and a.asset_issuer = t.asset_issuer
+        full outer join liquidity_pools_tvl as l
+            on coalesce(a.day, t.day) = l.day
+            and coalesce(a.asset_type, t.asset_type) = l.asset_type
+            and coalesce(a.asset_code, t.asset_code) = l.asset_code
+            and coalesce(a.asset_issuer, t.asset_issuer) = l.asset_issuer
     )
 
 select *

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -75,7 +75,7 @@ with
             , combined.asset_type
             , combined.asset_code
             , combined.asset_issuer
-            , a.contract_id
+            , a.asset_contract_id as contract_id
             , combined.accounts_tvl
             , combined.trustlines_tvl
             , combined.liquidity_pools_tvl

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -69,5 +69,23 @@ with
             and coalesce(a.asset_issuer, t.asset_issuer) = l.asset_issuer
     )
 
+    , final as (
+        select
+            combined.day
+            , combined.asset_type
+            , combined.asset_code
+            , combined.asset_issuer
+            , a.contract_id
+            , combined.accounts_tvl
+            , combined.trustlines_tvl
+            , combined.liquidity_pools_tvl
+            , combined.total_tvl
+        from combined
+        left join {{ ref('stg_assets') }} as a
+            on combined.asset_type = a.asset_type
+            and combined.asset_code = a.asset_code
+            and combined.asset_issuer = a.asset_issuer
+    )
+
 select *
-from combined
+from final

--- a/models/marts/tvl/tvl_agg.yml
+++ b/models/marts/tvl/tvl_agg.yml
@@ -2,7 +2,7 @@ version: 2
 
 models:
   - name: tvl_agg
-    description: "This table aggregates TVL from accounts and trustlines to calculate total TVL"
+    description: "This table aggregates TVL from accounts, trustlines, and liquidity pools to calculate total TVL"
     tests:
       - elementary.schema_changes:
           tags: [schema_changes]
@@ -54,6 +54,13 @@ models:
 
       - name: trustlines_tvl
         description: '{{ doc("trustlines_tvl") }}'
+        tests:
+          - stellar_dbt_public.incremental_not_null:
+              date_column_name: "day"
+              greater_than_equal_to: "2 day"
+
+      - name: liquidity_pools_tvl
+        description: '{{ doc("liquidity_pools_tvl") }}'
         tests:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

https://github.com/stellar/stellar-dbt/issues/645

### Why

SDF is taking over reporting TVL of our AMM from Lumenswap. This PR creates the `liquidity_pools_tvl` which is the raw asset balance of each asset locked for AMM.

Currently, `tvl_agg` only tracks DEX orderbook TVL via `selling_liabilities` from accounts (XLM) and trustlines (non-XLM). It completely misses AMM/liquidity pool TVL — the actual token amounts locked in pools. The `asset_balances__daily_agg` model already computes `liquidity_pool_balance` per asset per day (sourced from `int_account_balances__liquidity_pools`, which decomposes pool shares into underlying asset amounts). We're pulling this column into `tvl_agg` as a new `liquidity_pools_tvl` column.

### Known limitations

We will have to fully rebuild our `tvl_agg` model to include this new column so it has it historically
