### PR TITLE
[Bug 231] Fix to filter out empty strings for contract_id

### DIFF
--- a/models/docs/marts/hourly_soroban_fee_agg_contract.md
+++ b/models/docs/marts/hourly_soroban_fee_agg_contract.md
@@ -8,7 +8,7 @@ Strictly per-contract: Soroban operations without a resolvable contract_id are e
 * `invoke_host_function` / `upload_wasm` — no contract exists yet; the uploaded artifact is a `ContractCode` entry identified by its Wasm hash, not a contract address. stellar-etl emits `contract_id = NULL` for these.
 * `extend_footprint_ttl` and `restore_footprint` whose footprint touches only `ContractCode` / TTL entries (no `ContractData`) — stellar-etl emits `contract_id = ''` because there is no contract to resolve against. Instances of the same op types whose footprint *does* touch `ContractData` populate `contract_id` normally and are included.
 
-Because these rows are excluded, totals here do not represent total network-wide Soroban fees; use the network-level Soroban fee aggregation for that.
+Because these rows are excluded, totals here do not represent total network-wide Soroban fees; use the `daily_fee_stats_agg` or `ledger_fee_stats_agg` for full fee agg.
 
 Deduplicated to transaction grain to prevent double-counting fees if Soroban transactions support multiple operations in the future.
 

--- a/models/docs/marts/hourly_soroban_fee_agg_contract.md
+++ b/models/docs/marts/hourly_soroban_fee_agg_contract.md
@@ -4,7 +4,13 @@
 
 Hourly fee aggregation by contract, sourced from `enriched_history_operations_soroban`. Soroban-only by nature since contract_id only exists on Soroban operations. Provides attribution of fee activity to individual smart contracts, enabling identification of which contracts are driving fee volume or surge pricing.
 
-Soroban operations without a contract_id (e.g. WASM uploads) are excluded. Deduplicated to transaction grain to prevent double-counting fees if Soroban transactions support multiple operations in the future.
+Strictly per-contract: Soroban operations without a resolvable contract_id are excluded. This covers:
+* `invoke_host_function` / `upload_wasm` — no contract exists yet; the uploaded artifact is a `ContractCode` entry identified by its Wasm hash, not a contract address. stellar-etl emits `contract_id = NULL` for these.
+* `extend_footprint_ttl` and `restore_footprint` whose footprint touches only `ContractCode` / TTL entries (no `ContractData`) — stellar-etl emits `contract_id = ''` because there is no contract to resolve against. Instances of the same op types whose footprint *does* touch `ContractData` populate `contract_id` normally and are included.
+
+Because these rows are excluded, totals here do not represent total network-wide Soroban fees; use the network-level Soroban fee aggregation for that.
+
+Deduplicated to transaction grain to prevent double-counting fees if Soroban transactions support multiple operations in the future.
 
 One row per (hour, contract_id).
 
@@ -18,7 +24,7 @@ Hour-truncated UTC timestamp of the aggregation window. Derived from `timestamp_
 
 {% docs hourly_soroban_fee_agg_contract_id %}
 
-The Soroban smart contract address invoked by the transaction.
+The Soroban smart contract address (strkey `C...`) targeted by the transaction — either invoked directly (`invoke_host_function` / `invoke_contract`), deployed (`create_contract` / `create_contract_v2`), or touched via the transaction's Soroban footprint (`extend_footprint_ttl` / `restore_footprint` on `ContractData` entries). Never NULL or empty in this mart: rows without a resolvable contract_id are filtered out upstream.
 
 {% enddocs %}
 

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -46,9 +46,15 @@ with
             , rent_fee_charged
         from {{ ref('enriched_history_operations_soroban') }}
         where
-            -- Exclude Soroban operations not tied to a specific contract
-            -- (e.g. WASM uploads via invoke_host_function have no contract_id)
+            -- Exclude Soroban operations not tied to a specific contract:
+            --   * invoke_host_function / upload_wasm — contract_id is NULL
+            --     (no contract exists yet; the artifact is a ContractCode entry)
+            --   * extend_footprint_ttl / restore_footprint whose footprint
+            --     contains only ContractCode / TTL entries (no ContractData) —
+            --     stellar-etl emits contract_id as '' for these. Both NULL and
+            --     '' must be filtered to keep this mart strictly per-contract.
             contract_id is not null
+            and contract_id != ''
             and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
             {% if is_incremental() %}
                 and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))


### PR DESCRIPTION
<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise).
- [x] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes. <!-- N/A: filter-only change; existing tests still apply. -->
- [x] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* . <!-- patch-equivalent. -->
</details>

### What

Filter empty-string `contract_id` rows out of `hourly_soroban_fee_agg_contract`. Updates the model doc to match.

- `models/marts/hourly_soroban_fee_agg_contract.sql`: add `and contract_id != ''` to the filter.
- `models/docs/marts/hourly_soroban_fee_agg_contract.md`: doc the strict per-contract scope.

No schema, materialization, or ETL change.

### Why

Closes #231. 261 rows with `contract_id = ''` were leaking into the mart (earliest 2024-02). Root cause: stellar-etl emits `''` (not NULL) for `extend_footprint_ttl` / `restore_footprint` ops whose footprint touches only `ContractCode` (Wasm binary) entries — those ops don't target any specific contract, they maintain a shared Wasm. The existing `is not null` filter doesn't catch empty strings. Full trace + XDR verification across 9 txns is in #231.

Fix lives in dbt because the rows are semantically correct — they just don't belong in a *per-contract* aggregation. stellar-etl behavior (emit NULL instead of `''`) is a separate discussion and not a blocker.

### Known limitations

- **261 historical rows still exist in the live mart.** One-time cleanup after merge:
  ```sql
  delete from `crypto-stellar.crypto_stellar_dbt.hourly_soroban_fee_agg_contract`
  where contract_id = '';
  ```
  Or `dbt run --select hourly_soroban_fee_agg_contract --full-refresh`.
- Mart is strictly per-contract by design — does **not** represent total Soroban network fees. Wasm-maintenance ops (`upload_wasm`, code-only extend/restore) are excluded intentionally. Doc block now states this.