### PR TITLE
Bump click and dbt-bigquery (non-major)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-click==8.3.0
-dbt-bigquery==1.10.3
+click==8.3.2
+dbt-bigquery==1.11.1
 elementary-data[bigquery]==0.17.0
 MarkupSafe==2.0.1
 pre-commit==3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==8.3.2
+click==8.3.0
 dbt-bigquery==1.11.1
 elementary-data[bigquery]==0.17.0
 MarkupSafe==2.0.1


### PR DESCRIPTION
## Summary

Recreates Dependabot PR #228 against \`release-v20260505\`, with the click bump dropped because it conflicts with `sqlfluff 3.5.0` (caps `click<=8.3.0`). The original #228 hit the same CI failure.

## Applied

| Package | From | To |
|---|---|---|
| dbt-bigquery | 1.10.3 | 1.11.1 |

## Dropped

| Package | From | To | Why |
|---|---|---|---|
| click | 8.3.0 | 8.3.2 | sqlfluff 3.5.0 requires click<=8.3.0; bumping click also requires bumping sqlfluff (separate scope) |

## Skipped (major)

- #229 (major group)

## Test plan

- [ ] CI run on this PR

Supersedes #228 — close once green.