### PR TITLE
Move Dependabot day to Wednesday and ignore major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
       time: "02:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       minor-and-patch:
         applies-to: version-updates
         update-types:
           - "patch"
           - "minor"
-      major:
-        applies-to: version-updates
-        update-types:
-          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "sunday"
+      day: "wednesday"
       time: "02:00"
     open-pull-requests-limit: 2
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       all-actions:
         applies-to: version-updates


### PR DESCRIPTION
## Summary

Two small changes to `.github/dependabot.yml`:

1. **Schedule day moved sunday → wednesday** so Dependabot PRs land mid-week and aren't sitting through the weekend.
2. **Major-version upgrades ignored** via `ignore: [{dependency-name: "*", update-types: [version-update:semver-major]}]` on every `updates` entry. Major bumps were repeatedly creating PRs that couldn't pass CI due to transitive constraints (e.g. `apache-airflow-providers-cncf-kubernetes 10.16.1` requiring cryptography ≥44 vs `gcloud-aio-auth` capping at <42; `click 8.3.x` capped by `sqlfluff 3.5.0`). Major upgrades will be done manually when the surrounding deps can absorb them.

For the dbt/airflow repos that previously had a separate `major` group entry, that group is now redundant and removed.

## Test plan

- [ ] Verify YAML is valid (Dependabot will surface a config error in the repo's Insights → Dependency graph → Dependabot tab if not).