### PR TITLE
Quote github.head_ref in diff-quality workflow

### DIFF
--- a/.github/workflows/diff-quality.yml
+++ b/.github/workflows/diff-quality.yml
@@ -67,6 +67,8 @@ jobs:
           credentials_json: "${{ secrets.CREDS_TEST_HUBBLE }}"
 
       - name: Checkout source branch and diff quality
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          git checkout ${{ github.head_ref }}
+          git checkout "$HEAD_REF"
           diff-quality --violations=sqlfluff --exclude incremental_accepted_values.sql int_account_balances__contracts.sql --compare-branch=origin/master --fail-under=95


### PR DESCRIPTION
## Summary

`.github/workflows/diff-quality.yml` interpolates `${{ github.head_ref }}` directly into a `run:` shell block. Branch names can contain shell metacharacters, which matches the script-injection anti-pattern in GitHub's [security hardening guide][1]. Binding the ref to a step `env:` and quoting it in shell removes the injection surface.

Impact under the current configuration is limited (trigger is `pull_request` so fork PRs run with read-only `GITHUB_TOKEN` and no secrets, and the GCP auth step earlier in the job fails for fork PRs), but the fix is mechanical defense-in-depth and avoids regressions if the workflow is later reordered or switched to `pull_request_target`.

## Change

```yaml
- name: Checkout source branch and diff quality
  env:
    HEAD_REF: ${{ github.head_ref }}
  run: |
    git checkout "\$HEAD_REF"
    diff-quality ...
```

## Test plan

- [x] CI Linting workflow runs successfully on this PR (the workflow itself exercises the changed step).

[1]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections