### PR TITLE
Harden CI Linting and Release Drafter workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,37 +29,42 @@ jobs:
 
       - name: Get branch name
         id: getbranch
-        run: echo ::set-output name=BRANCH::${GITHUB_HEAD_REF}
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: echo "BRANCH=$HEAD_REF" >> "$GITHUB_OUTPUT"
 
       # ${{ github.ref }} was not giving v* as tag name, but refs/tags/v* instead, so I had to abbreviate it
       - name: Get latest abbreviated tag
         id: gettag
-        run: echo ::set-output name=TAG::$(git describe --tags $(git rev-list --tags --max-count=1)) # get the latest tag across all branches and put it in the output TAG
+        run: echo "TAG=$(git describe --tags $(git rev-list --tags --max-count=1))" >> "$GITHUB_OUTPUT"
 
       - name: Calculate next version
         id: nextversion
+        env:
+          BRANCH_NAME: ${{ steps.getbranch.outputs.BRANCH }}
+          CURRENT_VERSION: ${{ steps.gettag.outputs.TAG }}
         run: |
-          BRANCH_NAME="${{ steps.getbranch.outputs.BRANCH }}"
-          CURRENT_VERSION="${{ steps.gettag.outputs.TAG }}"
           CURRENT_VERSION="${CURRENT_VERSION#v}"  # Remove the 'v' from the start of the version
           IFS='.' read -ra VERSION_PARTS <<< "$CURRENT_VERSION"
-          if [[ $BRANCH_NAME =~ ^major/ ]]; then
+          if [[ "$BRANCH_NAME" =~ ^major/ ]]; then
             VERSION_PARTS[0]=$((VERSION_PARTS[0] + 1))
             VERSION_PARTS[1]=0
             VERSION_PARTS[2]=0
-          elif [[ $BRANCH_NAME =~ ^minor/ ]]; then
+          elif [[ "$BRANCH_NAME" =~ ^minor/ ]]; then
             VERSION_PARTS[1]=$((VERSION_PARTS[1] + 1))
             VERSION_PARTS[2]=0
           else
             VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
           fi
           NEXT_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
-          echo ::set-output name=NEXT_VERSION::"$NEXT_VERSION"
+          echo "NEXT_VERSION=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create and publish new tag
+        env:
+          NEXT_VERSION: ${{ steps.nextversion.outputs.NEXT_VERSION }}
         run: |
-          git tag ${{ steps.nextversion.outputs.NEXT_VERSION }}
-          git push origin ${{ steps.nextversion.outputs.NEXT_VERSION }}
+          git tag "$NEXT_VERSION"
+          git push origin "$NEXT_VERSION"
 
       - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 #v7.2.0
         with:


### PR DESCRIPTION
## Summary

- **diff-quality.yml**: bind `github.head_ref` to a step `env:` var and quote it in the shell. Removes the script-injection surface from a crafted PR branch name (matches GitHub's [Actions hardening guide][1]).
- **release.yml**: migrate the deprecated `::set-output` workflow command to `$GITHUB_OUTPUT`, and pass branch / version values through `env:` instead of re-interpolating them into bash. Closes the same injection class on the release path and unblocks future runner-image upgrades that drop `::set-output` support.

Impact under the current configuration is limited (fork PRs run with read-only `GITHUB_TOKEN` and no secrets, and the release job only runs on merged PRs which require write access), but the fixes are mechanical defense-in-depth and remove a tripwire if the workflow is ever reordered or the trigger changes.

## Test plan

- [ ] CI Linting workflow runs successfully on this PR (exercises the changed `diff-quality.yml` step).
- [ ] After merge, the next merged PR triggers Release Drafter and tags + publishes a release as before.

[1]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections