### PR TITLE
Quote github.head_ref in diff-quality workflow

### DIFF
--- a/.github/workflows/diff-quality.yml
+++ b/.github/workflows/diff-quality.yml
@@ -67,6 +67,8 @@ jobs:
           credentials_json: "${{ secrets.CREDS_TEST_HUBBLE }}"
 
       - name: Checkout source branch and diff quality
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          git checkout ${{ github.head_ref }}
+          git checkout "$HEAD_REF"
           diff-quality --violations=sqlfluff --exclude incremental_accepted_values.sql int_account_balances__contracts.sql --compare-branch=origin/master --fail-under=95


### PR DESCRIPTION
## Summary

Backport of the diff-quality `github.head_ref` hardening fix to `release-v20260501`. Same change as PR #247 (against `release-v20260512`) and PR #249 (against `master`).

Binds `github.head_ref` to a step `env:` var and quotes it in shell, following GitHub's [Actions hardening guide][1].

## Test plan

- [ ] CI Linting workflow runs successfully on this PR.

[1]: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections