### PR TITLE
Lag batch_end_date by 1 hour in eho_by_ops singular test

### DIFF
--- a/tests/eho_by_ops.sql
+++ b/tests/eho_by_ops.sql
@@ -25,13 +25,13 @@ WITH find_missing AS (
     -- Scan only the last 24 hours of data. Alert runs intraday so failures
     -- are caught and resolved quickly.
     AND op.batch_run_date >= DATETIME(TIMESTAMP_SUB(TIMESTAMP('{{ var("batch_start_date") }}'), INTERVAL 1 DAY ))
-    AND op.batch_run_date < DATETIME(TIMESTAMP('{{ var("batch_end_date") }}'))
+    AND op.batch_run_date < DATETIME(TIMESTAMP_SUB(TIMESTAMP('{{ var("batch_end_date") }}'), INTERVAL 1 HOUR))
 ),
 find_max_batch AS (
   SELECT MAX(batch_run_date) AS max_batch
   FROM {{ ref('stg_history_operations') }}
   WHERE batch_run_date >= DATETIME(TIMESTAMP_SUB(TIMESTAMP('{{ var("batch_start_date") }}'), INTERVAL 1 DAY ))
-    AND batch_run_date < DATETIME(TIMESTAMP('{{ var("batch_end_date") }}'))
+    AND batch_run_date < DATETIME(TIMESTAMP_SUB(TIMESTAMP('{{ var("batch_end_date") }}'), INTERVAL 1 HOUR))
 )
 SELECT batch_run_date,
     batch_id,


### PR DESCRIPTION
## Summary

- Shrinks the upper bound of the scan window in the `eho_by_ops` singular test by 1 hour for both the `find_missing` and `find_max_batch` CTEs.
- Prevents false-positive alerts on the most recent batch hour while `enriched_history_operations` is still catching up to `stg_history_operations`.

## Test plan

- [ ] Singular test is `enabled` only when `target.name == "prod"` and `is_singular_airflow_task == "true"` — verify in next Airflow singular-test run that the test compiles and runs without errors.
- [ ] Confirm no spurious alerts during the in-flight batch hour after deploy.