### PR TITLE
Migrate config_settings_snapshot from stellar-dbt to stellar-dbt-public

### DIFF
--- a/models/docs/marts/config_settings_snapshot.md
+++ b/models/docs/marts/config_settings_snapshot.md
@@ -1,0 +1,27 @@
+[comment]: < Configuration Settings Snapshot -
+
+{% docs config_settings_snapshot %}
+
+This table captures historical snapshots of various configuration settings from the Stellar network. It unpivots different metric values from the `config_settings` table and tracks their validity over time.
+
+Each metric represents a specific setting related to transaction limits, ledger constraints, fees, and other network parameters. The `valid_from` and `valid_to` timestamps help in identifying when each setting was active.
+
+{% enddocs %}
+
+{% docs config_setting_name %}
+
+The name of the configuration setting (metric) extracted from the source table. Each row represents a different setting tracked over time.
+
+{% enddocs %}
+
+{% docs setting_value %}
+
+The numeric value associated with the configuration setting. This value represents the active limit, fee, or constraint set by the network.
+
+{% enddocs %}
+
+{% docs is_current_setting %}
+
+Boolean flag indicating if the setting is currently in effect (`true` if `valid_to` is null).
+
+{% enddocs %}

--- a/models/marts/config_settings_snapshot.sql
+++ b/models/marts/config_settings_snapshot.sql
@@ -1,0 +1,67 @@
+{% set meta_config = {
+    "tags": ["network_stats"]
+} %}
+
+{{ config(
+    meta=meta_config,
+    **meta_config,
+    )
+}}
+
+{% set columns = adapter.get_columns_in_relation(ref('stg_config_settings')) %}
+
+{% set excluded_cols = [
+    'config_setting_id',
+    'contract_cost_params_cpu_insns',
+    'contract_cost_params_mem_bytes',
+    'deleted',
+    'batch_id',
+    'batch_run_date',
+    'batch_insert_ts',
+    'ledger_sequence',
+    'bucket_list_size_window',
+    'closed_at',
+    'airflow_start_ts',
+    'frozen_ledger_keys',
+    'frozen_ledger_keys_to_freeze',
+    'frozen_ledger_keys_to_unfreeze',
+    'freeze_bypass_txs',
+    'freeze_bypass_txs_to_add',
+    'freeze_bypass_txs_to_remove'
+] %}
+
+{% set filtered_cols = [] %}
+{% for col in columns %}
+    {% if col.name not in excluded_cols %}
+        {% do filtered_cols.append(col) %}
+    {% endif %}
+{% endfor %}
+
+with
+    unpivoted as (
+
+        {% for metric in filtered_cols %}
+            select
+                '{{ metric.name }}' as metric
+                , {{ metric.name }} as val
+                , closed_at as valid_from
+            from {{ ref('stg_config_settings') }}
+            where {{ metric.name }} <> 0
+            group by 1, 2, 3
+            {% if not loop.last %}
+                union all
+            {% endif %}
+        {% endfor %}
+    )
+select
+    *
+    , valid_to is null as is_current_setting
+from (
+    select
+        metric as config_setting_name
+        , val as setting_value
+        , valid_from
+        , lead(valid_from) over (partition by metric order by valid_from) as valid_to
+    from unpivoted
+)
+order by config_setting_name, valid_from

--- a/models/marts/config_settings_snapshot.yml
+++ b/models/marts/config_settings_snapshot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+models:
+  - name: config_settings_snapshot
+    description: '{{ doc("config_settings_snapshot") }}'
+    tests:
+      - elementary.schema_changes:
+          tags: [schema_changes]
+          config:
+            severity: warn
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - config_setting_name
+            - valid_from
+          meta:
+            description: "Tests the uniqueness combination of: config_setting_name and valid_from."
+    columns:
+      - name: config_setting_name
+        description: '{{ doc("config_setting_name") }}'
+        tests:
+          - not_null
+      - name: setting_value
+        description: '{{ doc("setting_value") }}'
+        tests:
+          - not_null
+      - name: valid_from
+        description: '{{ doc("valid_from") }}'
+        tests:
+          - not_null
+      - name: valid_to
+        description: '{{ doc("valid_to") }}'
+      - name: is_current_setting
+        description: '{{ doc("is_current_setting") }}'

--- a/models/marts/config_settings_snapshot.yml
+++ b/models/marts/config_settings_snapshot.yml
@@ -4,10 +4,6 @@ models:
   - name: config_settings_snapshot
     description: '{{ doc("config_settings_snapshot") }}'
     tests:
-      - elementary.schema_changes:
-          tags: [schema_changes]
-          config:
-            severity: warn
       - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - config_setting_name


### PR DESCRIPTION
### Summary
  Closes #235 
  Straight port of `config_settings_snapshot` from stellar-dbt.
                                                                                                         
  - No schema changes; preserves unpivot + SCD2 behavior
  - Verified locally: built in dev Hubble, output matches the existing                                   
    table built by stellar-dbt                                        
  - Addition only — the private copy in stellar-dbt will be removed
    in a follow-up PR after this is merged and tagged   

### Why

The config_settings_snapshot model currently lives in the private stellar-dbt repo. Downstream public-repo work — notably https://github.com/stellar/stellar-dbt-public/issues/189 (Soroban resource utilization mart) — needs this model as a public dependency so utilization ratios can be calculated against historical config setting limits.


