### PR TITLE
Microbatch int_token_transfer_enrichment and token_transfers

### DIFF
--- a/models/intermediate/account_balances/int_account_balances__contracts.sql
+++ b/models/intermediate/account_balances/int_account_balances__contracts.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "unique_key": ["day", "account_id", "contract_id"],
+    "event_time": "day",
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -22,7 +22,7 @@ with
         -- Microbatch supplies the batch window via model.batch; the else branch
         -- is only a compile-time placeholder (model.batch is unset outside a run).
         {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
             from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -19,13 +19,8 @@
 with
     dt as (
         select dates as day
-        -- Microbatch supplies the batch window via model.batch; the else branch
-        -- is only a compile-time placeholder (model.batch is unset outside a run).
-        {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% else %}
-            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
-        {% endif %}
+        -- Microbatch supplies the batch window via model.batch (set at run time).
+        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -1,23 +1,30 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {{ config(
     materialized='incremental',
-    incremental_strategy="insert_overwrite",
-    unique_key=["day", "account_id", "asset_code", "asset_issuer", "asset_type"],
+    incremental_strategy='microbatch',
+    event_time='day',
+    batch_size=batch_size,
+    concurrent_batches=flags.FULL_REFRESH,
+    begin='2023-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
-    incremental_predicates=["DBT_INTERNAL_DEST.day >= DATE('" ~ var('batch_start_date') ~ "')"]
 )}}
 
 with
     dt as (
         select dates as day
-        {% if is_incremental() %}
-            from unnest(generate_date_array(date('{{ var("batch_start_date") }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+        -- Microbatch supplies the batch window via model.batch; the else branch
+        -- is only a compile-time placeholder (model.batch is unset outside a run).
+        {% if model.batch %}
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=flags.FULL_REFRESH,
-    begin='2023-01-01',
+    begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
@@ -24,7 +24,7 @@ with
         {% if model.batch %}
             from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
+            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -1,24 +1,31 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {{ config(
     materialized='incremental',
-    incremental_strategy="insert_overwrite",
-    unique_key=["day", "account_id", "asset_code", "asset_issuer", "asset_type"],
+    incremental_strategy='microbatch',
+    event_time='day',
+    batch_size=batch_size,
+    concurrent_batches=flags.FULL_REFRESH,
+    begin='2023-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
-    incremental_predicates=["DBT_INTERNAL_DEST.day >= DATE('" ~ var('batch_start_date') ~ "')"]
     )
 }}
 
 with
     dt as (
         select dates as day
-        {% if is_incremental() %}
-            from unnest(generate_date_array(date('{{ var("batch_start_date") }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+        -- Microbatch supplies the batch window via model.batch; the else branch
+        -- is only a compile-time placeholder (model.batch is unset outside a run).
+        {% if model.batch %}
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -20,13 +20,8 @@
 with
     dt as (
         select dates as day
-        -- Microbatch supplies the batch window via model.batch; the else branch
-        -- is only a compile-time placeholder (model.batch is unset outside a run).
-        {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% else %}
-            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
-        {% endif %}
+        -- Microbatch supplies the batch window via model.batch (set at run time).
+        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=flags.FULL_REFRESH,
-    begin='2023-01-01',
+    begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
@@ -25,7 +25,7 @@ with
         {% if model.batch %}
             from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
+            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -23,7 +23,7 @@ with
         -- Microbatch supplies the batch window via model.batch; the else branch
         -- is only a compile-time placeholder (model.batch is unset outside a run).
         {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
             from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -22,7 +22,7 @@ with
         -- Microbatch supplies the batch window via model.batch; the else branch
         -- is only a compile-time placeholder (model.batch is unset outside a run).
         {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
             from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -1,23 +1,30 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {{ config(
     materialized='incremental',
-    incremental_strategy="insert_overwrite",
-    unique_key=["day", "account_id", "asset_code", "asset_issuer", "asset_type"],
+    incremental_strategy='microbatch',
+    event_time='day',
+    batch_size=batch_size,
+    concurrent_batches=flags.FULL_REFRESH,
+    begin='2023-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
-    incremental_predicates=["DBT_INTERNAL_DEST.day >= DATE('" ~ var('batch_start_date') ~ "')"]
 ) }}
 
 with
     dt as (
         select dates as day
-        {% if is_incremental() %}
-            from unnest(generate_date_array(date('{{ var("batch_start_date") }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+        -- Microbatch supplies the batch window via model.batch; the else branch
+        -- is only a compile-time placeholder (model.batch is unset outside a run).
+        {% if model.batch %}
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as dates
+            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -19,13 +19,8 @@
 with
     dt as (
         select dates as day
-        -- Microbatch supplies the batch window via model.batch; the else branch
-        -- is only a compile-time placeholder (model.batch is unset outside a run).
-        {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% else %}
-            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
-        {% endif %}
+        -- Microbatch supplies the batch window via model.batch (set at run time).
+        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=flags.FULL_REFRESH,
-    begin='2023-01-01',
+    begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
@@ -24,7 +24,7 @@ with
         {% if model.batch %}
             from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array('2023-01-01', '2023-01-01')) as dates
+            from unnest(generate_date_array('2021-01-01', '2021-01-01')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -1,12 +1,17 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": "unique_key",
-    "incremental_strategy": "merge",
+    "incremental_strategy": "microbatch",
+    "event_time": "closed_at",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "day"},
-    "incremental_predicates": ["DBT_INTERNAL_DEST.closed_at >= timestamp_sub(timestamp(date('" ~ var('batch_start_date') ~ "')), interval 1 day)"]
+        , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH},
 } %}
 
 {{ config(
@@ -44,11 +49,6 @@ with
         from {{ ref('stg_token_transfers_raw') }} as tt
         left join {{ ref('int_asset_metadata') }} as ac
             on tt.contract_id = ac.contract_id
-        where
-            tt.closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                and tt.closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
         group by 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 13, 14, 15, 16, 17
     )
     , operations as (
@@ -58,11 +58,6 @@ with
             , type_string as event_type
             , coalesce(`type` in (24, 25, 26), false) as is_soroban
         from {{ ref('stg_history_operations') }}
-        where
-            batch_run_date < datetime(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                and batch_run_date >= datetime(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
 select

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -58,6 +58,15 @@ with
             , type_string as event_type
             , coalesce(`type` in (24, 25, 26), false) as is_soroban
         from {{ ref('stg_history_operations') }}
+        {% if model.batch %}
+            -- history_operations is partitioned on batch_run_date, so the microbatch
+            -- closed_at filter alone cannot prune it. batch_run_date always falls within
+            -- a day of closed_at, so this buffered range restores partition pruning
+            -- without changing which rows qualify.
+            where
+                batch_run_date >= datetime_sub(datetime(timestamp('{{ model.batch.event_time_start }}')), interval 1 day)
+                and batch_run_date < datetime_add(datetime(timestamp('{{ model.batch.event_time_end }}')), interval 1 day)
+        {% endif %}
     )
 
 select

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.yml
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.yml
@@ -3,6 +3,14 @@ version: 2
 models:
   - name: int_token_transfer_enrichment
     description: "This table joins token_transfers_raw with history_operations to add operation type and soroban flag."
+    tests:
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
+          combination_of_columns:
+            - unique_key
+          date_column_name: "closed_at"
+          greater_than_equal_to: "1 day"
+          meta:
+            description: "Tests the uniqueness combination of: unique_key"
     columns:
       - name: transaction_hash
         description: '{{ doc("transaction_hash") }}'

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,11 +1,20 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
+{# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["day", "account_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "day",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2022-08-08",
+    "partition_by": {
+        "field": "day"
+        , "data_type": "date"
+        , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["tvl"]
 } %}
-
--- The earliest pricing data is at 2022-08-08 from stellar.expert for assets.
-{% set full_refresh_date = '2022-08-08' %}
 
 {{ config(
     meta=meta_config,
@@ -14,53 +23,46 @@
 }}
 
 -- To find the XLM TVL for a given day
---  * Get all account entries <= day
---  * Get the current value of the account_id for that day
+--  * Get each account's state as of that day from the SCD-2 accounts_snapshot
+--    (valid_from/valid_to), rather than reconstructing it from the raw change log
+--  * Take the XLM selling liabilities of the account for that day
 --  * Sum all the values for that day for all accounts
 
--- Dates that XLM TVL amount should be calculated for
 with
-    date_range as (
-        select day
-        {% if is_incremental() %}
-            from
-                unnest(generate_date_array(date('{{ var("batch_start_date") }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day)))
-                    as day
+    -- Microbatch supplies the batch window via model.batch; the else branch
+    -- is only a compile-time placeholder (model.batch is unset outside a run).
+    dt as (
+        select dates as day
+        {% if model.batch %}
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array(date('{{ full_refresh_date }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as day
+            from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}
     )
 
-    , xlm_tvl_per_day as (
+    , filtered_acc as (
         select
-            d.day
-            , a.account_id
-            , array_agg(a.selling_liabilities order by a.closed_at desc)[offset(0)] as tvl
-            , array_agg(a.deleted order by a.closed_at desc)[offset(0)] as deleted
-        from date_range as d
-        inner join {{ ref('stg_accounts') }} as a
-            on a.closed_at < timestamp(date_add(d.day, interval 1 day))
-            and a.closed_at < timestamp(date('{{ var("batch_end_date") }}'))
-        group by 1, 2
-    )
-
-    , daily_account_xlm_tvl as (
-        select
-            day
-            , account_id
-            , tvl
-        from xlm_tvl_per_day
+            acc.account_id
+            , acc.selling_liabilities
+            , acc.valid_from
+            , acc.valid_to
+        from {{ ref('accounts_snapshot') }} as acc
         where
-            true
-            and deleted = false
+            acc.deleted is false
+            and acc.valid_from < timestamp(date_add((select max(day) from dt), interval 1 day))
+            and (acc.valid_to is null or acc.valid_to >= timestamp((select min(day) from dt)))
     )
 
     , daily_xlm_tvl as (
         select
-            day
-            , account_id
-            , sum(tvl) as accounts_tvl
-        from daily_account_xlm_tvl
+            dt.day
+            , acc.account_id
+            , sum(acc.selling_liabilities) as accounts_tvl
+        from dt
+        inner join filtered_acc as acc
+            on
+            timestamp(dt.day) >= timestamp_trunc(acc.valid_from, day)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(acc.valid_to, day) or acc.valid_to is null)
         group by 1, 2
     )
 

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -29,14 +29,11 @@
 --  * Sum all the values for that day for all accounts
 
 with
-    -- Microbatch supplies the batch window via model.batch; the else branch
-    -- is only a compile-time placeholder (model.batch is unset outside a run).
+    -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
         {% if model.batch %}
             from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% else %}
-            from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -34,7 +34,7 @@ with
     dt as (
         select dates as day
         {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
             from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -32,9 +32,7 @@ with
     -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
-        {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% endif %}
+        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_acc as (

--- a/models/intermediate/tvl/int_tvl_accounts.yml
+++ b/models/intermediate/tvl/int_tvl_accounts.yml
@@ -3,6 +3,15 @@ version: 2
 models:
   - name: int_tvl_accounts
     description: "This table aggregates XLM selling liabilities from accounts to calculate TVL"
+    tests:
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - account_id
+          date_column_name: "day"
+          greater_than_equal_to: "2 day"
+          meta:
+            description: "Tests the uniqueness combination of: day, account_id."
     columns:
       - name: day
         description: '{{ doc("day") }}'

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -32,9 +32,7 @@ with
     -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
-        {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% endif %}
+        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,11 +1,20 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
+{# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["day", "account_id", "asset_code", "asset_issuer", "asset_type"],
+    "incremental_strategy": "microbatch",
+    "event_time": "day",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2022-08-08",
+    "partition_by": {
+        "field": "day"
+        , "data_type": "date"
+        , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["tvl"]
 } %}
-
--- The earliest asset pricing data is at 2022-08-08 from stellar.expert.
-{% set full_refresh_date = '2022-08-08' %}
 
 {{ config(
     meta=meta_config,
@@ -14,65 +23,52 @@
 }}
 
 -- To find the asset TVL for a given day
---  * Get all trustline entries <= day
---  * Get the current value of selling liabilities of the trustline for that day
+--  * Get each trustline's state as of that day from the SCD-2 trustlines_snapshot
+--    (valid_from/valid_to), rather than reconstructing it from the raw change log
+--  * Take the selling liabilities of the trustline for that day
 --  * Sum all the values for that day for all assets
 
--- Dates that asset to TVL amount should be calculated for
 with
-    date_range as (
-        select day
-        {% if is_incremental() %}
-            from
-                unnest(generate_date_array(date('{{ var("batch_start_date") }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day)))
-                    as day
+    -- Microbatch supplies the batch window via model.batch; the else branch
+    -- is only a compile-time placeholder (model.batch is unset outside a run).
+    dt as (
+        select dates as day
+        {% if model.batch %}
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
         {% else %}
-            from unnest(generate_date_array(date('{{ full_refresh_date }}'), date_sub(date('{{ var("batch_end_date") }}'), interval 1 day))) as day
+            from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}
     )
 
-    , filter_trustlines as (
+    , filtered_tl as (
         select
-            t.account_id
-            , t.asset_type
-            , t.asset_code
-            , t.asset_issuer
-            , t.selling_liabilities
-            , t.deleted
-            , t.closed_at
-        from {{ ref('stg_trust_lines') }} as t
+            tl.account_id
+            , tl.asset_type
+            , tl.asset_code
+            , tl.asset_issuer
+            , tl.selling_liabilities
+            , tl.valid_from
+            , tl.valid_to
+        from {{ ref('trustlines_snapshot') }} as tl
         where
-            true
-            and t.closed_at < timestamp(date('{{ var("batch_end_date") }}'))
-    )
-
-    , trustline_tvl_per_day as (
-        select
-            d.day
-            , t.account_id
-            , t.asset_type
-            , t.asset_code
-            , t.asset_issuer
-            , array_agg(t.selling_liabilities order by t.closed_at desc)[offset(0)] as tvl
-            , array_agg(t.deleted order by t.closed_at desc)[offset(0)] as deleted
-        from date_range as d
-        inner join filter_trustlines as t
-            on t.closed_at < timestamp(date_add(d.day, interval 1 day))
-        group by 1, 2, 3, 4, 5
+            tl.deleted is false
+            and tl.valid_from < timestamp(date_add((select max(day) from dt), interval 1 day))
+            and (tl.valid_to is null or tl.valid_to >= timestamp((select min(day) from dt)))
     )
 
     , daily_trustline_tvl as (
         select
-            day
-            , account_id
-            , asset_type
-            , asset_code
-            , asset_issuer
-            , sum(tvl) as trustlines_tvl
-        from trustline_tvl_per_day
-        where
-            true
-            and deleted = false
+            dt.day
+            , tl.account_id
+            , tl.asset_type
+            , tl.asset_code
+            , tl.asset_issuer
+            , sum(tl.selling_liabilities) as trustlines_tvl
+        from dt
+        inner join filtered_tl as tl
+            on
+            timestamp(dt.day) >= timestamp_trunc(tl.valid_from, day)
+            and (timestamp(date_add(dt.day, interval 1 day)) <= timestamp_trunc(tl.valid_to, day) or tl.valid_to is null)
         group by 1, 2, 3, 4, 5
     )
 

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -29,14 +29,11 @@
 --  * Sum all the values for that day for all assets
 
 with
-    -- Microbatch supplies the batch window via model.batch; the else branch
-    -- is only a compile-time placeholder (model.batch is unset outside a run).
+    -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
         {% if model.batch %}
             from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
-        {% else %}
-            from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}
     )
 

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -34,7 +34,7 @@ with
     dt as (
         select dates as day
         {% if model.batch %}
-            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(date(timestamp('{{ model.batch.event_time_end }}')), interval 1 day))) as dates
+            from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
         {% else %}
             from unnest(generate_date_array('2022-08-08', '2022-08-08')) as dates
         {% endif %}

--- a/models/intermediate/tvl/int_tvl_trustlines.yml
+++ b/models/intermediate/tvl/int_tvl_trustlines.yml
@@ -3,6 +3,18 @@ version: 2
 models:
   - name: int_tvl_trustlines
     description: "This table aggregates asset selling liabilities from trustlines to calculate TVL"
+    tests:
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - account_id
+            - asset_code
+            - asset_issuer
+            - asset_type
+          date_column_name: "day"
+          greater_than_equal_to: "2 day"
+          meta:
+            description: "Tests the uniqueness combination of: day, account_id, asset_code, asset_issuer, asset_type."
     columns:
       - name: day
         description: '{{ doc("day") }}'

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -6,7 +6,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": flags.FULL_REFRESH,
-    "begin": "2023-01-01",
+    "begin": "2021-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,15 +1,20 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "incremental_strategy": "insert_overwrite",
-    "unique_key": ["day", "account_id", "contract_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "day",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2023-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH
     },
     "cluster_by": ["account_id", "contract_id"],
     "tags": ["asset_balance_agg", "account_balance_agg"],
-    "incremental_predicates": ["DBT_INTERNAL_DEST.day >= DATE_SUB(DATE('" ~ var('batch_start_date') ~ "'), INTERVAL 1 DAY)"]
 } %}
 
 {{ config(
@@ -36,10 +41,6 @@ with
             -- TODO: Remove nulls for now until contract_ids are added to stellar-etl.
             -- These accounts would always have zero balance anyways so they have little impact
             and iabt.contract_id is not null
-            and iabt.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabt.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
     )
 
     , liquidity_pools_balance_changes as (
@@ -52,12 +53,6 @@ with
             , iablp.contract_id
             , iablp.balance as total_balance
         from {{ ref('int_account_balances__liquidity_pools') }} as iablp
-        where
-            true
-            and iablp.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iablp.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
     )
 
     , offer_balance_changes as (
@@ -70,12 +65,6 @@ with
             , iabo.contract_id
             , iabo.balance as total_balance
         from {{ ref('int_account_balances__offers') }} as iabo
-        where
-            true
-            and iabo.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabo.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
     )
 
     , contract_balance_changes as (
@@ -88,12 +77,6 @@ with
             , iabc.contract_id
             , iabc.balance as total_balance
         from {{ ref('int_account_balances__contracts') }} as iabc
-        where
-            true
-            and iabc.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabc.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
     )
 
     , day_account_asset_pairs_all as (

--- a/models/marts/account_balances/account_balances__daily_agg.yml
+++ b/models/marts/account_balances/account_balances__daily_agg.yml
@@ -16,7 +16,7 @@ models:
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."
-      - incremental_unique_combination_of_columns:
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
           combination_of_columns:
             - day
             - account_id
@@ -25,13 +25,6 @@ models:
           greater_than_equal_to: "2 day"
           meta:
             description: "Tests the uniqueness combination of: day, account_id, and contract_id."
-      - stellar_dbt_public.incremental_unique_combination_of_columns:
-          combination_of_columns:
-            - day
-            - account_id
-            - contract_id
-          date_column_name: "day"
-          greater_than_equal_to: "2 day"
     columns:
       - name: day
         description: '{{ doc("day_agg") }}'

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -6,7 +6,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": flags.FULL_REFRESH,
-    "begin": "2023-01-01",
+    "begin": "2021-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,14 +1,19 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "incremental_strategy": "insert_overwrite",
-    "unique_key": ["day", "contract_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "day",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2023-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH
     },
     "tags": ["asset_balance_agg"],
-    "incremental_predicates": ["DBT_INTERNAL_DEST.day >= DATE_SUB(DATE('" ~ var('batch_start_date') ~ "'), INTERVAL 1 DAY)"]
 } %}
 
 {{ config(
@@ -36,10 +41,6 @@ with
             and iabt.contract_id is not null
             -- Exclude XLM burn address
             and iabt.account_id != 'GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO'
-            and iabt.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabt.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
         group by 1, 2, 3, 4, 5
     )
 
@@ -58,10 +59,6 @@ with
             -- Exclude XLM burn address
             -- In theory there wouldn't be any XLM burn address LP but we can filter just in case
             and iablp.account_id != 'GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO'
-            and iablp.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iablp.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
         group by 1, 2, 3, 4, 5
     )
 
@@ -79,10 +76,6 @@ with
             true
             -- Exclude XLM burn address
             and iabo.account_id != 'GALAXYVOIDAOPZTDLHILAJQKCVVFMD4IKLXLSZV5YHO7VY74IWZILUTO'
-            and iabo.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabo.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
         group by 1, 2, 3, 4, 5
     )
 
@@ -96,12 +89,6 @@ with
             , sum(iabc.balance) as total_balance
             , count(case when iabc.balance > 0 then 1 end) as total_accounts_with_balance
         from {{ ref('int_account_balances__contracts') }} as iabc
-        where
-            true
-            and iabc.day < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and iabc.day >= date('{{ var("batch_start_date") }}')
-        {% endif %}
         group by 1, 2, 3, 4, 5
     )
 

--- a/models/marts/asset_balances/asset_balances__daily_agg.yml
+++ b/models/marts/asset_balances/asset_balances__daily_agg.yml
@@ -15,7 +15,7 @@ models:
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."
-      - incremental_unique_combination_of_columns:
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
           combination_of_columns:
             - day
             - contract_id
@@ -23,12 +23,6 @@ models:
           greater_than_equal_to: "2 day"
           meta:
             description: "Tests the uniqueness combination of: day and contract_id."
-      - stellar_dbt_public.incremental_unique_combination_of_columns:
-          combination_of_columns:
-            - day
-            - contract_id
-          date_column_name: "day"
-          greater_than_equal_to: "2 day"
     columns:
       - name: day
         description: '{{ doc("day_agg") }}'

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
     "materialized": "incremental",
@@ -11,7 +11,7 @@
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"
+        , "granularity": "day"
         , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["enriched_history_operations"],
 } %}
@@ -92,6 +92,15 @@ with
             , tx_signers
             , refundable_fee
         from {{ ref('stg_history_transactions') }}
+        {% if model.batch %}
+            -- history_transactions is partitioned on batch_run_date, so the microbatch
+            -- closed_at filter alone cannot prune it. batch_run_date always falls within
+            -- a day of closed_at, so this buffered range restores partition pruning
+            -- without changing which rows qualify.
+            where
+                batch_run_date >= datetime_sub(datetime(timestamp('{{ model.batch.event_time_start }}')), interval 1 day)
+                and batch_run_date < datetime_add(datetime(timestamp('{{ model.batch.event_time_end }}')), interval 1 day)
+        {% endif %}
     )
 
     , history_operations as (
@@ -216,6 +225,15 @@ with
             , operation_trace_code
             , details_json
         from {{ ref('stg_history_operations') }}
+        {% if model.batch %}
+            -- history_operations is partitioned on batch_run_date, so the microbatch
+            -- closed_at filter alone cannot prune it. batch_run_date always falls within
+            -- a day of closed_at, so this buffered range restores partition pruning
+            -- without changing which rows qualify.
+            where
+                batch_run_date >= datetime_sub(datetime(timestamp('{{ model.batch.event_time_start }}')), interval 1 day)
+                and batch_run_date < datetime_add(datetime(timestamp('{{ model.batch.event_time_end }}')), interval 1 day)
+        {% endif %}
     )
 
     , enriched_operations as (

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,13 +1,19 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["op_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "closed_at",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "cluster_by": ["ledger_sequence","transaction_id","op_account_id","type"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"},
+        , "granularity": "month"
+        , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["enriched_history_operations"],
-    "incremental_predicates":["DBT_INTERNAL_DEST.closed_at >= timestamp_sub(timestamp(date('" ~ var('batch_start_date') ~ "')), interval 1 day)"]
 } %}
 
 {{ config(
@@ -44,19 +50,6 @@ with
             , batch_id
             , batch_run_date
         from {{ ref('stg_history_ledgers') }}
-        where
-            -- Need to add/subtract one day to the window boundaries
-            -- because this model runs at 30 min increments.
-            -- Without the additional date buffering the following would occur
-            -- * batch_start_date == '2025-01-01 01:00:00' --> '2025-01-01'
-            -- * batch_end_date == '2025-01-01 01:30:00' --> '2025-01-01'
-            -- * '2025-01-01 <= closed_at < '2025-01-01' would never have any data to processes
-            closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                -- The extra day date_sub is useful in the case the first scheduled run for a day is skipped
-                -- because the DAG is configured with catchup=false
-                and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
     , history_transactions as (
@@ -99,11 +92,6 @@ with
             , tx_signers
             , refundable_fee
         from {{ ref('stg_history_transactions') }}
-        where
-            batch_run_date < datetime(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                and batch_run_date >= datetime(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
     , history_operations as (
@@ -228,12 +216,6 @@ with
             , operation_trace_code
             , details_json
         from {{ ref('stg_history_operations') }}
-        where
-            batch_run_date < datetime(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                and batch_run_date >= datetime(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
-
     )
 
     , enriched_operations as (

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -6,7 +6,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": flags.FULL_REFRESH,
-    "begin": "2015-09-30",
+    "begin": "2024-01-01",
     "cluster_by": ["ledger_sequence", "transaction_id", "op_type"],
     "partition_by": {
         "field": "closed_at"

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,13 +1,19 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["op_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "closed_at",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "cluster_by": ["ledger_sequence", "transaction_id", "op_type"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"},
+        , "granularity": "month"
+        , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["enriched_history_operations"],
-    "incremental_predicates":["DBT_INTERNAL_DEST.closed_at >= timestamp_sub(timestamp(date('" ~ var('batch_start_date') ~ "')), interval 1 day)"]
 } %}
 
 {{ config(
@@ -103,18 +109,6 @@ with
         from {{ ref('enriched_history_operations') }} as enriched
         where
             enriched.type in (24, 25, 26)
-            -- Need to add/subtract one day to the window boundaries
-            -- because this model runs at 30 min increments.
-            -- Without the additional date buffering the following would occur
-            -- * batch_start_date == '2025-01-01 01:00:00' --> '2025-01-01'
-            -- * batch_end_date == '2025-01-01 01:30:00' --> '2025-01-01'
-            -- * '2025-01-01 <= closed_at < '2025-01-01' would never have any data to processes
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-                -- The extra day date_sub is useful in the case the first scheduled run for a day is skipped
-                -- because the DAG is configured with catchup=false
-                and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
 select

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
     "materialized": "incremental",
@@ -11,7 +11,7 @@
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"
+        , "granularity": "day"
         , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["enriched_history_operations"],
 } %}

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,16 +1,20 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["hour_agg", "fee_source_account"],
+    "incremental_strategy": "microbatch",
+    "event_time": "hour_agg",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "fee_source_account"],
     "partition_by": {
         "field": "hour_agg",
         "data_type": "timestamp",
-        "granularity": "day"
+        "granularity": "day",
+        "copy_partitions": flags.FULL_REFRESH
     },
-    "incremental_predicates": [
-        "DBT_INTERNAL_DEST.hour_agg >= timestamp(date_sub(date('" ~ var("batch_start_date") ~ "'), interval 1 day))"
-    ]
 } %}
 
 {{ config(
@@ -46,11 +50,6 @@ with
             , refundable_resource_fee_charged
             , rent_fee_charged
         from {{ ref('stg_history_transactions') }}
-        where
-            closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-            {% if is_incremental() %}
-                and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
     , classified as (

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,16 +1,20 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["hour_agg", "contract_id"],
+    "incremental_strategy": "microbatch",
+    "event_time": "hour_agg",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "contract_id"],
     "partition_by": {
         "field": "hour_agg",
         "data_type": "timestamp",
-        "granularity": "day"
+        "granularity": "day",
+        "copy_partitions": flags.FULL_REFRESH
     },
-    "incremental_predicates": [
-        "DBT_INTERNAL_DEST.hour_agg >= timestamp(date_sub(date('" ~ var("batch_start_date") ~ "'), interval 1 day))"
-    ]
 } %}
 
 {{ config(
@@ -55,10 +59,6 @@ with
             --     '' must be filtered to keep this mart strictly per-contract.
             contract_id is not null
             and contract_id != ''
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-            {% if is_incremental() %}
-                and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
         -- Deduplicate to transaction grain. Soroban txns currently have
         -- 1 operation, but this handles (potential) future multi-op Soroban transactions
         -- so fees are not double-counted.

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -6,7 +6,7 @@
     "event_time": "hour_agg",
     "batch_size": batch_size,
     "concurrent_batches": flags.FULL_REFRESH,
-    "begin": "2015-09-30",
+    "begin": "2024-01-01",
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "contract_id"],
     "partition_by": {

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,6 +1,17 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "unique_key": ["ledger_sequence"],
+    "incremental_strategy": "microbatch",
+    "event_time": "day_agg",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
+    "partition_by": {
+        "field": "day_agg"
+        , "data_type": "date"
+        , "granularity": "day"
+        , "copy_partitions": flags.FULL_REFRESH},
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["day_agg", "ledger_sequence"]
 } %}
@@ -14,7 +25,7 @@ with
     -- BASE: source read + classification + effective_txn_operation_count
     base_txns as (
         select
-            cast(batch_run_date as date) as day_agg
+            date(closed_at) as day_agg
             , ledger_sequence
             , transaction_id
             , fee_charged
@@ -39,11 +50,6 @@ with
             , successful
             , coalesce(resource_fee, 0) > 0 as is_soroban
         from {{ ref('stg_history_transactions') }}
-        where
-            batch_run_date < datetime(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-            {% if is_incremental() %}
-                and batch_run_date >= datetime(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
     -- GENERAL AGGREGATES (all txns → ledger grain)
@@ -165,11 +171,6 @@ with
             , closed_at
             , fee_pool
         from {{ ref('stg_history_ledgers') }}
-        where
-            batch_run_date < datetime(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-            {% if is_incremental() %}
-                and batch_run_date >= datetime(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-            {% endif %}
     )
 
     , final as (

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -50,6 +50,15 @@ with
             , successful
             , coalesce(resource_fee, 0) > 0 as is_soroban
         from {{ ref('stg_history_transactions') }}
+        {% if model.batch %}
+            -- history_transactions is partitioned on batch_run_date, so the microbatch
+            -- closed_at filter alone cannot prune it. batch_run_date always falls within
+            -- a day of closed_at, so this buffered range restores partition pruning
+            -- without changing which rows qualify.
+            where
+                batch_run_date >= datetime_sub(datetime(timestamp('{{ model.batch.event_time_start }}')), interval 1 day)
+                and batch_run_date < datetime_add(datetime(timestamp('{{ model.batch.event_time_end }}')), interval 1 day)
+        {% endif %}
     )
 
     -- GENERAL AGGREGATES (all txns → ledger grain)

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,12 +1,18 @@
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+
 {% set meta_config = {
     "materialized": "incremental",
-    "incremental_strategy": "merge",
-    "unique_key": "unique_key",
+    "incremental_strategy": "microbatch",
+    "event_time": "closed_at",
+    "batch_size": batch_size,
+    "concurrent_batches": flags.FULL_REFRESH,
+    "begin": "2015-09-30",
     "tags": ["token_transfer"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"}
+        , "granularity": "month"
+        , "copy_partitions": flags.FULL_REFRESH}
 } %}
 
 {{ config(
@@ -17,8 +23,3 @@
 
 select *
 from {{ ref('int_token_transfer_enrichment') }}
-where
-    closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-    {% if is_incremental() %}
-        and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-    {% endif %}

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'month' %}
+{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
     "materialized": "incremental",
@@ -11,7 +11,7 @@
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
-        , "granularity": "month"
+        , "granularity": "day"
         , "copy_partitions": flags.FULL_REFRESH}
 } %}
 

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -1,6 +1,5 @@
 {% set meta_config = {
-    "materialized": "incremental",
-    "unique_key": ["day", "asset_code", "asset_issuer", "asset_type"],
+    "materialized": "table",
     "tags": ["tvl"]
 } %}
 

--- a/models/marts/tvl/tvl_agg.yml
+++ b/models/marts/tvl/tvl_agg.yml
@@ -16,6 +16,16 @@ models:
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."
+      - stellar_dbt_public.incremental_unique_combination_of_columns:
+          combination_of_columns:
+            - day
+            - asset_code
+            - asset_issuer
+            - asset_type
+          date_column_name: "day"
+          greater_than_equal_to: "2 day"
+          meta:
+            description: "Tests the uniqueness combination of: day, asset_code, asset_issuer, asset_type."
     columns:
       - name: day
         description: '{{ doc("day") }}'

--- a/models/staging/stg_contract_data.yml
+++ b/models/staging/stg_contract_data.yml
@@ -17,10 +17,10 @@ models:
           greater_than_equal_to: "2 day"
           combination_of_columns:
             - ledger_key_hash
-            - last_modified_ledger
+            - ledger_sequence
             - ledger_entry_change
           meta:
-            description: "Tests the uniqueness combination of: ledger_key_hash, last_modified_ledger, and ledger_entry_change."
+            description: "Tests the uniqueness combination of: ledger_key_hash, ledger_sequence, and ledger_entry_change."
     columns:
       - name: contract_id
         description: '{{ doc("contract_id") }}'


### PR DESCRIPTION
## What

Migrate following models to microbatch strategy:
- int_account balances* and account_balances
- int_token_transfer_enrichment and token_transfers
- int_tvl_accounts, int_tvl_trustlines
- eho


Run times for full refreshes of following marts:
1. TVL :  ~1 hour
2. asset_balance_agg: ~2 hours
3. token_transfer: 47
4. fee stats: 35 mins
5. EHO: 2 hours

## Companion PR

stellar/stellar-dbt#994 — `+event_time` on the staging inputs and the package pin.

### Testing Omni

<img width="418" height="611" alt="Screenshot 2026-07-14 at 4 25 30 PM" src="https://github.com/user-attachments/assets/7e0ee0c2-b688-46fc-8b49-35f3d54f23f1" />
<img width="450" height="627" alt="Screenshot 2026-07-14 at 4 25 42 PM" src="https://github.com/user-attachments/assets/a638a425-56d6-496d-9b8e-f1d35d0a1cbf" />

<img width="399" height="775" alt="Screenshot 2026-07-14 at 4 29 51 PM" src="https://github.com/user-attachments/assets/fd238635-cbe6-40a9-ac0c-0ff587cd6052" />
<img width="437" height="783" alt="Screenshot 2026-07-14 at 4 30 04 PM" src="https://github.com/user-attachments/assets/e45b08f0-e875-4d95-90b1-b1d4e1170018" />
