### PR TITLE
Asset code contract tokens v2

### DIFF
--- a/models/docs/marts/account_balances/account_balances__daily_agg.md
+++ b/models/docs/marts/account_balances/account_balances__daily_agg.md
@@ -4,4 +4,6 @@
 
 Table containing the daily aggregate of account balances.
 
+For contract tokens, `asset_code` is resolved via `int_asset_metadata`: it coalesces the asset_code from SAC token transfer events with the SEP-41 `symbol` from contract storage metadata. The value is null when a contract publishes neither.
+
 {% enddocs %}

--- a/models/docs/marts/asset_balances/asset_balances__daily_agg.md
+++ b/models/docs/marts/asset_balances/asset_balances__daily_agg.md
@@ -4,6 +4,8 @@
 
 Table containing the daily aggregate of asset balances.
 
+For contract tokens, `asset_code` is resolved via `int_asset_metadata`: it coalesces the asset_code from SAC token transfer events with the SEP-41 `symbol` from contract storage metadata. The value is null when a contract publishes neither.
+
 {% enddocs %}
 
 {% docs day_agg %}

--- a/models/docs/universal.md
+++ b/models/docs/universal.md
@@ -24,7 +24,9 @@ The 4 or 12 character code representation of the asset on the network.
 
 #### Notes:
 
-Asset codes have no guarantees of uniqueness. The combination of asset code, issuer and type represents a distinct asset
+Asset codes have no guarantees of uniqueness. The combination of asset code, issuer and type represents a distinct asset.
+
+For contract tokens, `asset_code` is resolved via `int_asset_metadata`, which coalesces the asset_code from SAC transfer events with the SEP-41 `symbol` from contract storage metadata. The value is null when a contract publishes neither a SAC asset_code nor a SEP-41 `symbol` — recognized assets are enriched upstream in `stg_assets`, so a null `asset_code` on a contract-token row means the contract publishes no on-chain identifying metadata.
 {% enddocs %}
 
 {% docs asset_issuer %}

--- a/models/intermediate/account_balances/int_account_balances__contracts.sql
+++ b/models/intermediate/account_balances/int_account_balances__contracts.sql
@@ -21,17 +21,15 @@
 -- re-aggregating from the start of smart contracts (2024-02-20) to current is very quick and not compute intensive.
 -- TODO: account_ids should really be named addresses; This can be refactored in the future if needed
 with
-    -- Amounts should be added when assets are sent to the account
+    -- Amounts should be added when assets are sent to the account.
+    -- `amount` arrives pre-scaled (10^-decimal applied) from int_token_transfer_enrichment.
     token_transfers_to as (
         select
             date(tt.closed_at) as day
             , tt.to as account_id
             , tt.contract_id
-            -- Note that 10^-7 is the default precision for Stellar assets. Recognized assets with default precision will have null token_precision.
-            , sum(safe_cast(tt.amount_raw as numeric) * pow(10, coalesce(-safe_cast(metadata.decimal as int64), -7))) as balance
-        from {{ ref('stg_token_transfers_raw') }} as tt
-        left join {{ ref('int_asset_metadata') }} as metadata
-            on tt.contract_id = metadata.contract_id
+            , sum(tt.amount) as balance
+        from {{ ref('int_token_transfer_enrichment') }} as tt
         where
             true
             and tt.to is not null
@@ -41,17 +39,14 @@ with
         group by 1, 2, 3
     )
 
-    -- Amounts should be subtracted when assets are sent from the account
+    -- Amounts should be subtracted when assets are sent from the account.
     , token_transfers_from as (
         select
             date(tt.closed_at) as day
             , tt.`from` as account_id
             , tt.contract_id
-            -- Note that 10^-7 is the default precision for Stellar assets. Recognized assets with default precision will have null token_precision.
-            , -sum(safe_cast(tt.amount_raw as numeric) * pow(10, coalesce(-safe_cast(metadata.decimal as int64), -7))) as balance
-        from {{ ref('stg_token_transfers_raw') }} as tt
-        left join {{ ref('int_asset_metadata') }} as metadata
-            on tt.contract_id = metadata.contract_id
+            , -sum(tt.amount) as balance
+        from {{ ref('int_token_transfer_enrichment') }} as tt
         where
             true
             and tt.`from` is not null
@@ -135,5 +130,5 @@ select
     , a.asset_code
     , agg.balance
 from agg
-left join {{ ref('stg_assets') }} as a
-    on agg.contract_id = a.asset_contract_id
+left join {{ ref('int_asset_metadata') }} as a
+    on agg.contract_id = a.contract_id

--- a/models/intermediate/account_balances/int_account_balances__contracts.yml
+++ b/models/intermediate/account_balances/int_account_balances__contracts.yml
@@ -33,6 +33,9 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+          - relationships:
+              to: ref('int_asset_metadata')
+              field: contract_id
 
       - name: balance
         description: '{{ doc("balance") }}'

--- a/models/intermediate/int_asset_metadata.sql
+++ b/models/intermediate/int_asset_metadata.sql
@@ -9,12 +9,26 @@
 }}
 
 with
-    unique_contracts as (
+    asset_per_contract as (
+        -- stg_assets.asset_contract_id is unique (see stg_assets.yml), so no aggregation needed.
+        select
+            asset_contract_id as contract_id
+            , nullif(asset_code, '') as asset_code
+            , nullif(asset_issuer, '') as asset_issuer
+            , nullif(asset_type, '') as asset_type
+        from {{ ref('stg_assets') }}
+        where asset_contract_id is not null
+    )
+
+    -- SEP-41 / SAC metadata read directly from contract storage.
+    , unique_contracts as (
         select distinct contract_id
         from {{ ref('stg_token_transfers_raw') }}
         -- filter only for soroban contracts
         where closed_at >= '2024-02-01'
-    ), contract_metadata as (
+    )
+
+    , contract_metadata as (
         select
             uc.contract_id
             , cd.val_decoded
@@ -22,7 +36,9 @@ with
         left join {{ ref('contract_data_current') }} as cd
             on uc.contract_id = cd.contract_id
         where cd.contract_key_type = 'ScValTypeScvLedgerKeyContractInstance'
-    ), flattened_data as (
+    )
+
+    , flattened_data as (
         select
             contract_id
             , json_value(m.key.symbol) as metadata_key
@@ -36,13 +52,44 @@ with
         -- left join unnest the map array (since Admin doesn't have a map, it would be filtered out otherwise)
         left join unnest(json_query_array(s.val.map)) as m
     )
+
+    , metadata as (
+        select
+            contract_id
+            -- Extract Admin (from the storage level)
+            , max(if(admin_key = 'Admin', admin_address, null)) as `admin`
+            -- Extract Metadata (from the map level)
+            , max(if(metadata_key = 'symbol', val_string, null)) as `symbol`
+            , max(if(metadata_key = 'name', val_string, null)) as `name`
+            , max(if(metadata_key in ('decimal', 'decimals'), val_u32, null)) as `decimal`
+        from flattened_data
+        group by contract_id
+    )
+
+    , all_contracts as (
+        select contract_id from asset_per_contract
+        union distinct
+        select contract_id from metadata
+    )
+
 select
-    contract_id
-    -- Extract Admin (from the storage level)
-    , max(if(admin_key = 'Admin', admin_address, null)) as `admin`
-    -- Extract Metadata (from the map level)
-    , max(if(metadata_key = 'symbol', val_string, null)) as `symbol`
-    , max(if(metadata_key = 'name', val_string, null)) as `name`
-    , max(if(metadata_key in ('decimal', 'decimals'), val_u32, null)) as `decimal`
-from flattened_data
-group by contract_id
+    c.contract_id
+    -- Resolves to the SAC asset_code from token-transfer events, falling back to the SEP-41
+    -- symbol read from contract storage. Returns null when neither is available — downstream
+    -- consumers must handle null asset_code for contract tokens that publish no metadata.
+    , coalesce(a.asset_code, m.symbol) as asset_code
+    , a.asset_issuer
+    , a.asset_type
+    , m.symbol
+    , m.`name`
+    , m.`decimal`
+    , m.admin
+    , case
+        when a.asset_code is not null then 'sac'
+        when m.symbol is not null then 'metadata'
+    end as asset_code_source
+from all_contracts as c
+left join asset_per_contract as a
+    on c.contract_id = a.contract_id
+left join metadata as m
+    on c.contract_id = m.contract_id

--- a/models/intermediate/int_asset_metadata.sql
+++ b/models/intermediate/int_asset_metadata.sql
@@ -72,6 +72,28 @@ with
         select contract_id from metadata
     )
 
+    -- SAC rows carry no contract-storage metadata of their own, so `decimal` is null on
+    -- the SAC row. When a SAC and a SEP-41 contract share the same asset_code AND the
+    -- SAC's asset_issuer matches the SEP-41's admin, we treat the SEP-41 as the SAC's
+    -- sibling and let the SAC inherit the SEP-41's decimals. This avoids the failure
+    -- mode where a SAC of an 18-decimal SEP-41 token gets scaled at the default 10^-7
+    -- in downstream amount calculations. The issuer/admin guard prevents cross-linking
+    -- unrelated tokens that happen to share an asset_code.
+    , sac_sibling_decimals as (
+        select
+            a.contract_id as sac_contract_id
+            , m.`decimal` as sibling_decimal
+        from asset_per_contract as a
+        inner join metadata as m
+            on a.asset_code = m.symbol
+            and a.asset_issuer = m.admin
+        where m.`decimal` is not null
+        qualify row_number() over (
+            partition by a.contract_id
+            order by m.`decimal` desc
+        ) = 1
+    )
+
 select
     c.contract_id
     -- Resolves to the SAC asset_code from token-transfer events, falling back to the SEP-41
@@ -82,7 +104,7 @@ select
     , a.asset_type
     , m.symbol
     , m.`name`
-    , m.`decimal`
+    , coalesce(m.`decimal`, s.sibling_decimal) as `decimal`
     , m.admin
     , case
         when a.asset_code is not null then 'sac'
@@ -93,3 +115,5 @@ left join asset_per_contract as a
     on c.contract_id = a.contract_id
 left join metadata as m
     on c.contract_id = m.contract_id
+left join sac_sibling_decimals as s
+    on c.contract_id = s.sac_contract_id

--- a/models/intermediate/int_asset_metadata.yml
+++ b/models/intermediate/int_asset_metadata.yml
@@ -2,18 +2,37 @@ version: 2
 
 models:
   - name: int_asset_metadata
-    description: "This model captures metadata about Stellar assets associated with contracts involved in token transfers."
+    description: "One row per contract_id with the contract's asset_code (coalesced from stg_assets SAC asset_code, then SEP-41 symbol read from contract storage) plus the SEP-41 metadata fields (symbol, name, decimal, admin) read directly from contract instance storage. asset_code is null when neither a SAC asset_code nor a SEP-41 symbol is available — recognized assets are enriched upstream in stg_assets, so a null here means the contract publishes no metadata."
     columns:
       - name: contract_id
         description: '{{ doc("contract_id") }}'
         tests:
           - not_null
           - unique
-      - name: admin
-        description: '{{ doc("contract_admin") }}'
+
+      - name: asset_code
+        description: '{{ doc("asset_code") }}'
+
+      - name: asset_issuer
+        description: '{{ doc("asset_issuer") }}'
+
+      - name: asset_type
+        description: '{{ doc("asset_type") }}'
+
       - name: symbol
         description: '{{ doc("contract_symbol") }}'
+
       - name: name
         description: '{{ doc("contract_name") }}'
+
       - name: decimal
         description: '{{ doc("decimal_precision") }}'
+
+      - name: admin
+        description: '{{ doc("contract_admin") }}'
+
+      - name: asset_code_source
+        description: "Indicates which source the asset_code came from: 'sac' = asset_code from a Stellar Asset Contract token transfer event, 'metadata' = SEP-41 symbol read from contract storage. Null when no asset_code could be resolved (asset_code is also null in that case)."
+        tests:
+          - accepted_values:
+              values: ["sac", "metadata"]

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -28,19 +28,22 @@ with
             -- Original token transfers only built asset_code:asset_issuer, it dropped asset_type for all assets less XLM
             , replace(tt.asset, substr(tt.asset, 1, instr(tt.asset, ':')), '') as asset
             , tt.asset_type
-            , tt.asset_code
+            -- For contract tokens that don't expose asset_code on transfer events, fall back to
+            -- int_asset_metadata which coalesces with SEP-41 symbol metadata (null when neither
+            -- a SAC asset_code nor a SEP-41 symbol is available).
+            , coalesce(nullif(tt.asset_code, ''), ac.asset_code) as asset_code
             , tt.asset_issuer
             , safe_cast(sum(safe_cast(tt.amount_raw as numeric)) as string) as amount_raw
             -- should we be safe_casting decimal as int64 or something else here?
-            , sum(safe_cast(tt.amount_raw as numeric) * pow(10, coalesce(-safe_cast(metadata.decimal as int64), -7))) as amount
+            , sum(safe_cast(tt.amount_raw as numeric) * pow(10, coalesce(-safe_cast(ac.decimal as int64), -7))) as amount
             , tt.contract_id
             , tt.ledger_sequence
             , tt.closed_at
             , tt.to_muxed
             , tt.to_muxed_id
         from {{ ref('stg_token_transfers_raw') }} as tt
-        left join {{ ref('int_asset_metadata') }} as metadata
-            on tt.contract_id = metadata.contract_id
+        left join {{ ref('int_asset_metadata') }} as ac
+            on tt.contract_id = ac.contract_id
         where
             tt.closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
         {% if is_incremental() %}

--- a/tests/int_token_transfer_enrichment_amount_matches_current_metadata.sql
+++ b/tests/int_token_transfer_enrichment_amount_matches_current_metadata.sql
@@ -1,0 +1,54 @@
+-- Catches stale-baked-in scaling in int_token_transfer_enrichment. The stored
+-- `amount` is computed at write time as amount_raw * 10^-decimal using whatever
+-- int_asset_metadata returned at that moment. If int_asset_metadata had a gap
+-- in decimal resolution when a row was materialized (e.g., contract metadata
+-- wasn't yet ingested into contract_data_current), the row gets baked in with
+-- the default 10^-7 fallback instead of the correct decimal. Later metadata
+-- fixes don't retroactively update those historical rows.
+--
+-- This test recomputes amount against current metadata and fails on rows where
+-- the stored value disagrees by more than a tolerance. Tolerance is high enough
+-- to ignore float64 precision noise on large summed values but low enough to
+-- catch genuine scaling regressions (which are typically off by 10^11 or more
+-- when the wrong decimal is used).
+--
+-- Context: deJAAA/deJTRSY incident on 2026-05-15. See
+-- POSTMORTEM_DEJAAA_DEJTRSY_2026-05-15.md in stellar-dbt for details.
+
+{{ config(
+    severity="error"
+    , tags=["singular_test"]
+    , meta={"alert_suppression_interval": 24}
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
+    , alert_suppression_interval=24
+    )
+}}
+
+with current_metadata as (
+    select
+        contract_id
+        , safe_cast(`decimal` as int64) as decimal_int
+    from {{ ref('int_asset_metadata') }}
+)
+
+, daily_compare as (
+    select
+        date(tt.closed_at) as day
+        , tt.contract_id
+        , sum(tt.amount) as stored_total
+        , sum(safe_cast(tt.amount_raw as numeric) * pow(10, coalesce(-cm.decimal_int, -7))) as recomputed_total
+    from {{ ref('int_token_transfer_enrichment') }} as tt
+    left join current_metadata as cm
+        on tt.contract_id = cm.contract_id
+    where tt.closed_at >= timestamp('2024-02-01')
+    group by 1, 2
+)
+
+select
+    day
+    , contract_id
+    , stored_total
+    , recomputed_total
+    , abs(stored_total - recomputed_total) as abs_diff
+from daily_compare
+where abs(stored_total - recomputed_total) > 100

--- a/tests/sac_asset_code_matches_metadata_symbol.sql
+++ b/tests/sac_asset_code_matches_metadata_symbol.sql
@@ -1,0 +1,29 @@
+-- For contract tokens that publish both an asset_code via SAC transfer events
+-- and a SEP-41 symbol in their contract storage metadata, the two should agree.
+-- A mismatch indicates either a misconfigured SAC, a custom contract impersonating
+-- a recognized asset, or a data-quality issue worth investigating.
+--
+-- Known exception: the XLM SAC contract publishes "native" as its symbol while
+-- our staging layer rewrites the asset_code to "XLM" for ergonomics.
+-- This was confirmed against production data on 2026-05-06; no other mismatches existed.
+
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
+{{ config(
+    severity="error"
+    , tags=["singular_test"]
+    , meta={"alert_suppression_interval": 24}
+    , enabled=(target.name == "prod" and var("is_singular_airflow_task") == "true")
+    , alert_suppression_interval=24
+    )
+}}
+
+select
+    contract_id
+    , asset_code
+    , symbol
+from {{ ref('int_asset_metadata') }}
+where asset_code_source = 'sac'
+    and symbol is not null
+    and asset_code != symbol
+    and contract_id != 'CAS3J7GYLGXMF6TDJBBYYSE3HQ6BBSMLNUQ34T6TZMYMW2EVH34XOWMA'


### PR DESCRIPTION
### What

Restores the HUBBLE-677 contract token resolution work (originally PR #248, reverted by #262), plus two new safeguards on top:

1. **SAC sibling decimals fallback** in `int_asset_metadata`: when a SAC and a SEP-41 contract share the same `asset_code` AND the SAC's `asset_issuer` matches the SEP-41's `admin`, the SAC row inherits the SEP-41's `decimal` instead of returning null.
2. **New singular test** `int_token_transfer_enrichment_amount_matches_current_metadata` that recomputes stored `amount` against current `int_asset_metadata.decimal` and fails on rows whose stored value disagrees by more than 100 absolute units.

### Why

#248 was reverted on 2026-05-18 because pre-existing stale rows from January 2026 in `int_token_transfer_enrichment` (scaled at 10⁻⁷ instead of 10⁻¹⁸ due to a metadata-resolution gap at write time) got surfaced by the refactored `int_account_balances__contracts`. The deJAAA/deJTRSY balances on Margarita's Omni RWA chart inflated by ~10¹¹x.

The two new safeguards prevent recurrence:
- The sibling fallback ensures SACs of higher-decimal SEP-41 tokens get the correct decimals in `int_asset_metadata`, so downstream amount scaling doesn't default to 10⁻⁷.
- The singular test catches any stale-baked-in scaling in enrichment, regardless of when it was introduced. Catches the original issue and any future metadata-resolution gaps.

Full context in stellar-dbt's `POSTMORTEM_DEJAAA_DEJTRSY_2026-05-15.md`.

### Known limitations

- The SAC sibling fallback requires `asset_issuer = admin` to match. For tokens where the SEP-41's `admin` is a contract address (C-address) rather than the issuer's G-address, the fallback won't trigger. Acceptable for the deJAAA/deJTRSY case which motivated this change.
- The singular test tolerance is set to 100 absolute units; tight enough to catch genuine scaling regressions (typically off by 10¹¹+) but loose enough to ignore float64 precision noise on huge summed values.

### Testing
- [x] I have tested my changes locally or in dev airflow
- [ ] I have added or updated relevant datafold alerts
