### PR TITLE
Update stg_contract_data uniqueness test to use ledger_sequence

### DIFF
--- a/models/staging/stg_contract_data.yml
+++ b/models/staging/stg_contract_data.yml
@@ -17,10 +17,10 @@ models:
           greater_than_equal_to: "2 day"
           combination_of_columns:
             - ledger_key_hash
-            - last_modified_ledger
+            - ledger_sequence
             - ledger_entry_change
           meta:
-            description: "Tests the uniqueness combination of: ledger_key_hash, last_modified_ledger, and ledger_entry_change."
+            description: "Tests the uniqueness combination of: ledger_key_hash, ledger_sequence, and ledger_entry_change."
     columns:
       - name: contract_id
         description: '{{ doc("contract_id") }}'


### PR DESCRIPTION
Change the `incremental_unique_combination_of_columns` test grain on `stg_contract_data` from `[ledger_key_hash, last_modified_ledger, ledger_entry_change]` to `[ledger_key_hash, ledger_sequence, ledger_entry_change]`.

Uniqueness of a contract-data row within a ledger change is keyed by the ledger it was observed in (`ledger_sequence`), not the ledger it was last modified in (`last_modified_ledger`) — the latter repeats across observed ledgers. `ledger_sequence` already exists in the model (`stg_contract_data.sql`).

Standalone change, independent of the microbatch work. Targeting `release-v20260714`.