### PR TITLE
Add note making this repo out-of-scope for bug bounty rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,7 @@ In order to apply git tagging properly, the last commit message from a repo must
 # Futher Development
 
 TODO
+
+---
+
+> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy and Bug Bounty Eligibility
+
+stellar-dbt-public is excluded from Stellar's bug bounty program.
+
+To review the details of the program, see the [Stellar bug bounty program](https://www.stellar.org/bug-bounty-program/).


### PR DESCRIPTION
### What

Adds a `SECURITY.md` and a note in the README that make this repo out-of-scope for bug bounty rewards.

### Why

As this repo is a dbt data transformation project, it was never intended to be eligible for bug bounty rewards.