### PR TITLE
Disable claimable_balances_current model

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,3 +309,7 @@ In order to apply git tagging properly, the last commit message from a repo must
 # Futher Development
 
 TODO
+
+---
+
+> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy and Bug Bounty Eligibility
+
+stellar-dbt-public is excluded from Stellar's bug bounty program.
+
+To review the details of the program, see the [Stellar bug bounty program](https://www.stellar.org/bug-bounty-program/).

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -48,6 +48,9 @@ models:
       +materialized: table # how the intermediate models will be materialized
     marts:
       +materialized: table # how the mart models will be materialized
+      ledger_current_state:
+        claimable_balances_current:
+          +enabled: false
     snapshots:
       +materialized: incremental_snapshot
 

--- a/tests/no_missing_ledgers.sql
+++ b/tests/no_missing_ledgers.sql
@@ -30,7 +30,6 @@
     'trust_lines_current',
     'offers_current',
     'liquidity_pools_current',
-    'claimable_balances_current',
     'contract_data_current',
     'contract_code_current',
     'config_settings_current',


### PR DESCRIPTION
## Description

Disables the `claimable_balances_current` mart via `+enabled: false` in `dbt_project.yml`.

Also removes `claimable_balances_current` from the `current_tables` list in `tests/no_missing_ledgers.sql` — with the model disabled, the `ref()` there would fail compilation when the singular test task runs in Airflow (`IS_SINGULAR_AIRFLOW_TASK=true`).

## Verification

- `dbt parse` succeeds
- `dbt ls --select claimable_balances_current` → no enabled nodes
- `IS_SINGULAR_AIRFLOW_TASK=true dbt ls --select no_missing_ledgers` still resolves
- `pre-commit` passes on changed files