### PR TITLE
Add datadiff configs to mart models for WAP backfill validation

### DIFF
--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -16,11 +16,17 @@
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
 )}}
 
+{# model.batch is only set at microbatch run time; fall back to the batch
+   vars so parse/compile (e.g. `dbt compile` in CI) renders without a batch
+   context. #}
+{% set window_start = model.batch.event_time_start if model.batch else var("batch_start_date") %}
+{% set window_end = model.batch.event_time_end if model.batch else var("batch_end_date") %}
+
 with
     dt as (
         select dates as day
         -- Microbatch supplies the batch window via model.batch (set at run time).
-        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
+        from unnest(generate_date_array(date(timestamp('{{ window_start }}')), date_sub(least(date(timestamp('{{ window_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -17,11 +17,17 @@
     )
 }}
 
+{# model.batch is only set at microbatch run time; fall back to the batch
+   vars so parse/compile (e.g. `dbt compile` in CI) renders without a batch
+   context. #}
+{% set window_start = model.batch.event_time_start if model.batch else var("batch_start_date") %}
+{% set window_end = model.batch.event_time_end if model.batch else var("batch_end_date") %}
+
 with
     dt as (
         select dates as day
         -- Microbatch supplies the batch window via model.batch (set at run time).
-        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
+        from unnest(generate_date_array(date(timestamp('{{ window_start }}')), date_sub(least(date(timestamp('{{ window_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -16,11 +16,17 @@
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
 ) }}
 
+{# model.batch is only set at microbatch run time; fall back to the batch
+   vars so parse/compile (e.g. `dbt compile` in CI) renders without a batch
+   context. #}
+{% set window_start = model.batch.event_time_start if model.batch else var("batch_start_date") %}
+{% set window_end = model.batch.event_time_end if model.batch else var("batch_end_date") %}
+
 with
     dt as (
         select dates as day
         -- Microbatch supplies the batch window via model.batch (set at run time).
-        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
+        from unnest(generate_date_array(date(timestamp('{{ window_start }}')), date_sub(least(date(timestamp('{{ window_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -28,11 +28,17 @@
 --  * Take the XLM selling liabilities of the account for that day
 --  * Sum all the values for that day for all accounts
 
+{# model.batch is only set at microbatch run time; fall back to the batch
+   vars so parse/compile (e.g. `dbt compile` in CI) renders without a batch
+   context. #}
+{% set window_start = model.batch.event_time_start if model.batch else var("batch_start_date") %}
+{% set window_end = model.batch.event_time_end if model.batch else var("batch_end_date") %}
+
 with
     -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
-        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
+        from unnest(generate_date_array(date(timestamp('{{ window_start }}')), date_sub(least(date(timestamp('{{ window_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_acc as (

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -28,11 +28,17 @@
 --  * Take the selling liabilities of the trustline for that day
 --  * Sum all the values for that day for all assets
 
+{# model.batch is only set at microbatch run time; fall back to the batch
+   vars so parse/compile (e.g. `dbt compile` in CI) renders without a batch
+   context. #}
+{% set window_start = model.batch.event_time_start if model.batch else var("batch_start_date") %}
+{% set window_end = model.batch.event_time_end if model.batch else var("batch_end_date") %}
+
 with
     -- Microbatch supplies the batch window via model.batch (set at run time).
     dt as (
         select dates as day
-        from unnest(generate_date_array(date(timestamp('{{ model.batch.event_time_start }}')), date_sub(least(date(timestamp('{{ model.batch.event_time_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
+        from unnest(generate_date_array(date(timestamp('{{ window_start }}')), date_sub(least(date(timestamp('{{ window_end }}')), date('{{ var("batch_end_date") }}')), interval 1 day))) as dates
     )
 
     , filtered_tl as (

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -5,7 +5,7 @@
         "unique_key": ["day", "account_id", "contract_id"],
         "exclude_columns": [],
         "min_match_percent": 98,
-        "filters": {"column": "day", "default_start": "2021-01-01"},
+        "filters": {"column": "day"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["day", "account_id", "contract_id"],
+        "exclude_columns": [],
+        "min_match_percent": 98,
+        "filters": {"column": "day", "default_start": "2021-01-01"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "day",

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -5,7 +5,7 @@
         "unique_key": ["day", "contract_id"],
         "exclude_columns": [],
         "min_match_percent": 98,
-        "filters": {"column": "day", "default_start": "2021-01-01"},
+        "filters": {"column": "day"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["day", "contract_id"],
+        "exclude_columns": [],
+        "min_match_percent": 98,
+        "filters": {"column": "day", "default_start": "2021-01-01"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "day",

--- a/models/marts/daily_fee_stats_agg.sql
+++ b/models/marts/daily_fee_stats_agg.sql
@@ -3,7 +3,7 @@
         "unique_key": ["day_agg"],
         "exclude_columns": ["airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+        "filters": {"column": "day_agg"},
     },
     "materialized": "incremental",
     "unique_key": ["day_agg"],

--- a/models/marts/daily_fee_stats_agg.sql
+++ b/models/marts/daily_fee_stats_agg.sql
@@ -1,4 +1,10 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["day_agg"],
+        "exclude_columns": ["airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "unique_key": ["day_agg"],
     "tags": ["daily_fee_stats"],

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -5,7 +5,7 @@
         "unique_key": ["op_id"],
         "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+        "filters": {"column": "closed_at"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["op_id"],
+        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -3,7 +3,7 @@
 {% set meta_config = {
     "datadiff": {
         "unique_key": ["op_id"],
-        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "exclude_columns": ["batch_id", "batch_run_date", "batch_insert_ts", "airflow_start_ts"],
         "min_match_percent": 98,
         "filters": {"column": "closed_at"},
     },

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -3,7 +3,7 @@
 {% set meta_config = {
     "datadiff": {
         "unique_key": ["op_id"],
-        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "exclude_columns": ["batch_id", "batch_run_date", "batch_insert_ts", "airflow_start_ts"],
         "min_match_percent": 98,
         "filters": {"column": "closed_at"},
     },

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["op_id"],
+        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "closed_at", "default_start": "2024-01-01"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -5,7 +5,7 @@
         "unique_key": ["op_id"],
         "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "closed_at", "default_start": "2024-01-01"},
+        "filters": {"column": "closed_at"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/evicted_keys.sql
+++ b/models/marts/evicted_keys.sql
@@ -3,7 +3,7 @@
         "unique_key": ["ledger_key_hash", "closed_at"],
         "exclude_columns": [],
         "min_match_percent": 98,
-        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+        "filters": {"column": "closed_at"},
     },
     "materialized": "incremental",
     "incremental_strategy": "merge",

--- a/models/marts/evicted_keys.sql
+++ b/models/marts/evicted_keys.sql
@@ -1,4 +1,10 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["ledger_key_hash", "closed_at"],
+        "exclude_columns": [],
+        "min_match_percent": 98,
+        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "merge",
     "unique_key": ["ledger_key_hash", "closed_at"],

--- a/models/marts/history_assets.sql
+++ b/models/marts/history_assets.sql
@@ -1,7 +1,7 @@
 {% set meta_config = {
     "datadiff": {
         "unique_key": ["asset_id"],
-        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "exclude_columns": ["batch_id", "batch_run_date", "batch_insert_ts", "airflow_start_ts"],
         "min_match_percent": 98,
     },
     "materialized": "incremental",

--- a/models/marts/history_assets.sql
+++ b/models/marts/history_assets.sql
@@ -1,4 +1,9 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["asset_id"],
+        "exclude_columns": ["batch_id", "batch_run_date", "airflow_start_ts"],
+        "min_match_percent": 98,
+    },
     "materialized": "incremental",
     "unique_key": ["asset_id"],
     "cluster_by": ["asset_id"],

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -5,7 +5,7 @@
         "unique_key": ["hour_agg", "fee_source_account"],
         "exclude_columns": ["airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "hour_agg", "default_start": "2015-09-30"},
+        "filters": {"column": "hour_agg"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["hour_agg", "fee_source_account"],
+        "exclude_columns": ["airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "hour_agg", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "hour_agg",

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -5,7 +5,7 @@
         "unique_key": ["hour_agg", "contract_id"],
         "exclude_columns": ["airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "hour_agg", "default_start": "2024-01-01"},
+        "filters": {"column": "hour_agg"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["hour_agg", "contract_id"],
+        "exclude_columns": ["airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "hour_agg", "default_start": "2024-01-01"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "hour_agg",

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["ledger_sequence"],
+        "exclude_columns": ["batch_run_date", "airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "day_agg",

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -5,7 +5,7 @@
         "unique_key": ["ledger_sequence"],
         "exclude_columns": ["batch_run_date", "airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+        "filters": {"column": "day_agg"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/soroban_core_metrics.sql
+++ b/models/marts/soroban_core_metrics.sql
@@ -3,7 +3,7 @@
         "unique_key": ["transaction_hash", "metric_key"],
         "exclude_columns": ["airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "closed_at", "default_start": "2024-01-01"},
+        "filters": {"column": "closed_at"},
     },
     "materialized": "incremental",
     "incremental_strategy": "insert_overwrite",

--- a/models/marts/soroban_core_metrics.sql
+++ b/models/marts/soroban_core_metrics.sql
@@ -1,4 +1,10 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["transaction_hash", "metric_key"],
+        "exclude_columns": ["airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "closed_at", "default_start": "2024-01-01"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "insert_overwrite",
     "tags": ["soroban_core_metrics"],

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,6 +1,12 @@
 {% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
 
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["unique_key"],
+        "exclude_columns": [],
+        "min_match_percent": 98,
+        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -5,7 +5,7 @@
         "unique_key": ["unique_key"],
         "exclude_columns": [],
         "min_match_percent": 98,
-        "filters": {"column": "closed_at", "default_start": "2015-09-30"},
+        "filters": {"column": "closed_at"},
     },
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/trade_agg.sql
+++ b/models/marts/trade_agg.sql
@@ -3,7 +3,7 @@
         "unique_key": ["day_agg", "asset_a", "asset_b"],
         "exclude_columns": ["airflow_start_ts"],
         "min_match_percent": 98,
-        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+        "filters": {"column": "day_agg"},
     },
     "materialized": "incremental",
     "unique_key": ["day_agg", "asset_a", "asset_b"],

--- a/models/marts/trade_agg.sql
+++ b/models/marts/trade_agg.sql
@@ -1,4 +1,10 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["day_agg", "asset_a", "asset_b"],
+        "exclude_columns": ["airflow_start_ts"],
+        "min_match_percent": 98,
+        "filters": {"column": "day_agg", "default_start": "2015-09-30"},
+    },
     "materialized": "incremental",
     "unique_key": ["day_agg", "asset_a", "asset_b"],
     "cluster_by": ["asset_a", "asset_b"],

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -1,4 +1,10 @@
 {% set meta_config = {
+    "datadiff": {
+        "unique_key": ["day", "asset_code", "asset_issuer", "asset_type"],
+        "exclude_columns": [],
+        "min_match_percent": 98,
+        "filters": {"column": "day", "default_start": "2021-01-01"},
+    },
     "materialized": "table",
     "tags": ["tvl"]
 } %}

--- a/models/marts/tvl/tvl_agg.sql
+++ b/models/marts/tvl/tvl_agg.sql
@@ -3,7 +3,6 @@
         "unique_key": ["day", "asset_code", "asset_issuer", "asset_type"],
         "exclude_columns": [],
         "min_match_percent": 98,
-        "filters": {"column": "day", "default_start": "2021-01-01"},
     },
     "materialized": "table",
     "tags": ["tvl"]


### PR DESCRIPTION
Adds a `config.datadiff` block to each mart/gold/omni_pdt model so the `dbt_backfill`DAG runs a datadiff between prod and prod_backfill datasets. (Also relevant for staging)

Each block defines:
- **`unique_key`** → Datafold `pk_columns` (from the model's config or uniqueness test)
- **`exclude_columns`** → the load/metadata columns present on the model (`batch_id`, `batch_run_date`, `batch_insert_ts`, `airflow_start_ts`) that legitimately differ live-vs-backfill
- **`min_match_percent: 98`**
- **`filters: {column, default_start}`** for time-partitioned models, so the diff is bounded to a window — `resolve_models` injects the backfill DAG's `event_time` window and falls back to `default_start`
