### PR TITLE
deprecated note to use amount_raw

### DIFF
--- a/models/docs/sources/token_transfers_raw.md
+++ b/models/docs/sources/token_transfers_raw.md
@@ -29,7 +29,7 @@ The destination address for the token transfer event amount
 {% enddocs %}
 
 {% docs amount_float %}
-The normalized float amount of the asset. Raw amount of asset * 0.0000001
+**DEPRECATED, prefer `amount_raw`.** This column applies a fixed scale of 7 decimals (raw amount of asset * 0.0000001) to every event, but token contracts declare their own decimal precision. As a result this value is incorrect for any token that does not use 7 decimals (off by a factor of 10^(7 - real_decimals)). Use `amount_raw` (always correct) and scale by the token's declared decimals. Correctly scaled amounts are already recomputed downstream in the dbt `token_transfers` model.
 {% enddocs %}
 
 {% docs amount_raw %}


### PR DESCRIPTION
### What

**Add a deprecation note to the `token_transfers_raw.amount` column doc**, steering readers to `amount_raw`.

### Why

`amount` hardcodes a fixed 7-decimal scale (`amount_raw` * 0.0000001) in stellar-etl's `token_transfer.go`, regardless of the token's declared decimals, so it is wrong for any non-7-decimal token. The dbt layer already recomputes the correctly scaled amount from `amount_raw` downstream (`int_token_transfer_enrichment`), so marts are unaffected, but the `amount_float` doc block gave no warning. This adds the caveat so it shows in dbt docs.

Part of a set with stellar/stellar-etl-airflow#956 (BQ column description) and stellar/stellar-docs#2632 (public data dictionary).

### Known limitations

Doc-only. The underlying scaling behavior in stellar-etl is not changed here.

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [x] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [x] This PR avoids mixing refactoring changes with feature changes (split into two PRs otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [x] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [x] I've decided if this PR requires a new major/minor/patch version accordingly to [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>