### PR TITLE
Remove incremental behavior from full-rebuild table models

### DIFF
--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {{ config(
     materialized='incremental',

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {{ config(
     materialized='incremental',

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {{ config(
     materialized='incremental',

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "materialized": "incremental",

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/daily_fee_stats_agg.sql
+++ b/models/marts/daily_fee_stats_agg.sql
@@ -20,11 +20,6 @@ with
     ledger_stats as (
         select *
         from {{ ref('ledger_fee_stats_agg') }}
-        where
-            day_agg < date('{{ var("batch_end_date") }}')
-            {% if is_incremental() %}
-                and day_agg >= date('{{ var("batch_start_date") }}')
-            {% endif %}
     )
 
     , final as (

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/evicted_keys.sql
+++ b/models/marts/evicted_keys.sql
@@ -24,20 +24,6 @@ with
             , true as is_evicted
         from {{ ref('stg_history_ledgers') }} as shl
         cross join unnest(shl.evicted_ledger_keys_hash) as kh
-        where
-            true
-            -- Need to add/subtract one day to the window boundaries
-            -- because this model runs at 30 min increments.
-            -- Without the additional date buffering the following would occur
-            -- * batch_start_date == '2025-01-01 01:00:00' --> '2025-01-01'
-            -- * batch_end_date == '2025-01-01 01:30:00' --> '2025-01-01'
-            -- * '2025-01-01 <= closed_at < '2025-01-01' would never have any data to processes
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-            -- The extra day date_sub is useful in the case the first scheduled run for a day is skipped
-            -- because the DAG is configured with catchup=false
-            and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-    {% endif %}
     )
 
     , restored as (
@@ -47,12 +33,6 @@ with
             , ledger_sequence
             , false as is_evicted
         from {{ ref('stg_restored_key') }}
-        where
-            true
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-            and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-    {% endif %}
     )
 
 select * from evicted

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/trade_agg.sql
+++ b/models/marts/trade_agg.sql
@@ -24,45 +24,21 @@ with
     trade_daily as (
         select *
         from {{ ref('int_trade_agg_day') }}
-        where
-            true
-            and day_agg < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and day_agg >= date('{{ var("batch_start_date") }}')
-    {% endif %}
     )
 
     , trade_weekly as (
         select *
         from {{ ref('int_trade_agg_week') }}
-        where
-            true
-            and day_agg < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and day_agg >= date('{{ var("batch_start_date") }}')
-    {% endif %}
     )
 
     , trade_monthly as (
         select *
         from {{ ref('int_trade_agg_month') }}
-        where
-            true
-            and day_agg < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and day_agg >= date('{{ var("batch_start_date") }}')
-    {% endif %}
     )
 
     , trade_yearly as (
         select *
         from {{ ref('int_trade_agg_year') }}
-        where
-            true
-            and day_agg < date('{{ var("batch_end_date") }}')
-        {% if is_incremental() %}
-            and day_agg >= date('{{ var("batch_start_date") }}')
-    {% endif %}
     )
 
     , join_trades as (


### PR DESCRIPTION
## What

Removes leftover incremental behavior from six models that are materialized as `table`:
`int_asset_stats_agg`, `asset_stats_agg`, `tvl_agg_recognized_assets`, `tvl_agg_usd`,
`int_entity__account_activity_history`, `int_entity__account_types`.

Each affected CTE now reduces to a plain `select … from {{ ref(...) }}` — no `is_incremental()`,
no `batch_start_date`, no `batch_end_date` (and the dead `{{ this }}` self-merge branch in
`int_entity__account_activity_history` is collapsed to its non-incremental branch).

## Why

These are full-rebuild tables, but several still applied a **live `batch_end_date` upper bound**
outside the `is_incremental()` guard. Under a `partial_backfill` (see stellar/stellar-dbt#986)
`batch_end_date` is a *past* date, so the rebuild would truncate to the window end and the
whole-table swap would publish a truncated table over live — silent data loss. Removing all
batch-date coupling makes these tables rebuild whole history and immune to window truncation
under any run mode.

`int_entity__account_activity_history` / `int_entity__account_types`: table mode already took the
non-incremental branch, so this only deletes dead code (no behavior change).

## Test plan

- SQL diffs are pure deletions of filter blocks; no dangling `where`/`and`.
- CI: sqlfluff + dbt model-doc/tag checks (need a compiled manifest, not runnable locally).

Part of the partial-refresh backfill work (stellar/stellar-dbt#986). Paired with the
stellar-etl-airflow PR that adds windowed partial_backfill validation.


---

## Also in this PR: microbatch `batch_size` override

Each microbatch model hardcoded `batch_size = 'year' if flags.FULL_REFRESH else 'day'`. It now reads an optional env var, falling back to that same default when unset/empty:

```jinja
{% set batch_size = env_var('DBT_MICROBATCH_BATCH_SIZE', '') or ('year' if flags.FULL_REFRESH else 'day') %}
```

This lets a run (e.g. a large `partial_backfill`) coarsen batch granularity to month/year without a code change. `env_var()` (not a dbt var / `--vars`) is used because the backfill build runs under `in_pod_retries`, whose `bash -c` wrapping is incompatible with `--vars`. The `'' or (...)` guard is required because a defined-but-empty value would otherwise bypass the default. Runs that do not set the env var behave exactly as before. The Airflow-side `batch_size` trigger param that sets `DBT_MICROBATCH_BATCH_SIZE` is in stellar/stellar-etl-airflow#959.
