### PR TITLE
sources: env-driven database/schema; microbatch_begin() for CI windows

### DIFF
--- a/macros/microbatch_begin.sql
+++ b/macros/microbatch_begin.sql
@@ -1,0 +1,25 @@
+{# Returns the `begin` date string for a microbatch incremental model.
+
+   Non-ci targets get the default (typically the project's earliest data,
+   e.g. '2015-09-30'). Under target=ci, return today - N days so slim-ci
+   first-builds only walk a short window instead of every day from the
+   project's epoch. N defaults to 30 and can be overridden by the
+   `microbatch_ci_window_days` var so a CI run can widen the window via
+   --vars without editing this macro.
+
+   Uses `run_started_at` (a timezone-aware pendulum UTC datetime that is
+   constant for the whole run) so every model in a run computes the same
+   window and there is no drift across a UTC midnight boundary.
+
+   Usage:
+       {% set begin = microbatch_begin() %}
+       {% set meta_config = { "begin": begin, ... } %}
+#}
+{% macro microbatch_begin(default='2015-09-30') %}
+    {%- if target.name == 'ci' -%}
+        {%- set window_days = var('microbatch_ci_window_days', 30) | int -%}
+        {{ return((run_started_at - modules.datetime.timedelta(days=window_days)).strftime('%Y-%m-%d')) }}
+    {%- else -%}
+        {{ return(default) }}
+    {%- endif -%}
+{% endmacro %}

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "materialized": "incremental",
@@ -6,7 +7,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2022-08-08') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -7,7 +8,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2022-08-08",
+    "begin": begin,
     "partition_by": {
         "field": "day"
         , "data_type": "date"

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2022-08-08') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -7,7 +8,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2022-08-08",
+    "begin": begin,
     "partition_by": {
         "field": "day"
         , "data_type": "date"

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2021-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2021-01-01",
+    "begin": begin,
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2021-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2021-01-01",
+    "begin": begin,
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "cluster_by": ["ledger_sequence","transaction_id","op_account_id","type"],
     "partition_by": {
         "field": "closed_at"

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2024-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2024-01-01",
+    "begin": begin,
     "cluster_by": ["ledger_sequence", "transaction_id", "op_type"],
     "partition_by": {
         "field": "closed_at"

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "hour_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "fee_source_account"],
     "partition_by": {

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2024-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "hour_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2024-01-01",
+    "begin": begin,
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "contract_id"],
     "partition_by": {

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "partition_by": {
         "field": "day_agg"
         , "data_type": "date"

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "tags": ["token_transfer"],
     "partition_by": {
         "field": "closed_at"

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: accounts
         description: '{{ doc("accounts") }}'

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: account_signers
         description: '{{ doc("accounts_signers") }}'

--- a/models/sources/src_claimable_balances.yml
+++ b/models/sources/src_claimable_balances.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: claimable_balances
         description: '{{ doc("claimable_balances") }}'

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: config_settings
         description: '{{ doc("config_settings") }}'

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: contract_code
         description: '{{ doc("contract_code") }}'

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: contract_data
         description: '{{ doc("contract_data") }}'

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_assets_staging
         description: '{{ doc("history_assets_staging") }}'

--- a/models/sources/src_history_contract_events.yml
+++ b/models/sources/src_history_contract_events.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_contract_events
         description: '{{ doc("history_contract_events") }}'

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_effects
         description: '{{ doc("history_effects") }}'

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_ledgers
         description: '{{ doc("history_ledgers") }}'

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_operations
         description: '{{ doc("history_operations") }}'

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_trades
         description: '{{ doc("history_trades") }}'

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_transactions
         description: '{{ doc("history_transactions") }}'

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: liquidity_pools
         description: '{{ doc("liquidity_pools") }}'

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: offers
         description: '{{ doc("liquidity_pools") }}'

--- a/models/sources/src_restored_key.yml
+++ b/models/sources/src_restored_key.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: restored_key
         description: '{{ doc("restored_key") }}'

--- a/models/sources/src_token_transfers_raw.yml
+++ b/models/sources/src_token_transfers_raw.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: token_transfers_raw
         description: '{{ doc("token_transfers_raw") }}'

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: trust_lines
         description: '{{ doc("trust_lines") }}'

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: ttl
         description: '{{ doc("ttl") }}'


### PR DESCRIPTION
Root fix for stellar/stellar-dbt#1067: CI builds of this package's models intermittently read prod (`crypto-stellar.crypto_stellar`) instead of the CI sample, because the parent project redirects these sources with dbt's **deprecated** source `overrides:` feature, which resolves nondeterministically on CI runners under dbt 1.12 (full evidence in the issue: same commit, same workflow, same env, different resolution minutes apart; 36k slot-minutes burned against prod in one day).

## What changes

**1. Sources carry their own env-driven resolution** (all 19 `models/sources/src_*.yml`):

```yaml
database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
```

This is the exact jinja the parent's override uses today, moved to where the sources are declared, so every environment resolves identically and the override becomes deletable. No override machinery, no nondeterminism, by construction.

**2. `microbatch_begin()` ported and the 11 hardcoded `begin` dates converted**, each model's original date preserved as the non-ci default. Under `target=ci` the microbatch models walk a 30-day window instead of full history (a full-history walk is ~3950 day-batches per model against a sample holding 2 days of data, which is what ground the parent's CI reference builds into GitHub's 6h job cap).

## Verification (parsed the parent project against this branch, override deleted, dbt-core 1.12.0rc3)

| context | sources resolve to | begins |
| --- | --- | --- |
| target=ci, `PUBLIC_SOURCE_SCHEMA=dbt_sample_ci` | `test-hubble-319619.dbt_sample_ci` x19 | today-30d |
| target=prod, no env vars | `crypto-stellar.crypto_stellar` x19 | every model's original date |

## After merge (parent repo, will follow)

Tag a release, bump the pin in stellar-dbt, delete the `overrides:` block (`models/sources/dev_sources.yml`), and pin dbt-core explicitly.

Generated with [Claude Code](https://claude.com/claude-code)