### PR TITLE
Release v20260804

### DIFF
--- a/macros/microbatch_batch_size.sql
+++ b/macros/microbatch_batch_size.sql
@@ -1,0 +1,25 @@
+{# Returns the `batch_size` for a microbatch model.
+
+   1. `DBT_MICROBATCH_BATCH_SIZE` if set -- Airflow's per-run override, mostly
+      for partial backfills.
+   2. `year` on a full refresh, so rebuilding all history is not thousands of
+      day-sized batches.
+   3. `day` otherwise, matching the scheduled cadence.
+
+   `batch_size` must be at least as coarse as the model's
+   `partition_by.granularity`, so a model partitioned coarser than `day` should
+   pass its own `default`.
+
+   Usage:
+       {% set batch_size = microbatch_batch_size() %}
+#}
+{% macro microbatch_batch_size(default='day', full_refresh_default='year') %}
+    {%- set override = env_var('DBT_MICROBATCH_BATCH_SIZE', '') -%}
+    {%- if override -%}
+        {{ return(override) }}
+    {%- elif flags.FULL_REFRESH -%}
+        {{ return(full_refresh_default) }}
+    {%- else -%}
+        {{ return(default) }}
+    {%- endif -%}
+{% endmacro %}

--- a/macros/microbatch_begin.sql
+++ b/macros/microbatch_begin.sql
@@ -1,0 +1,25 @@
+{# Returns the `begin` date string for a microbatch incremental model.
+
+   Non-ci targets get the default (typically the project's earliest data,
+   e.g. '2015-09-30'). Under target=ci, return today - N days so slim-ci
+   first-builds only walk a short window instead of every day from the
+   project's epoch. N defaults to 30 and can be overridden by the
+   `microbatch_ci_window_days` var so a CI run can widen the window via
+   --vars without editing this macro.
+
+   Uses `run_started_at` (a timezone-aware pendulum UTC datetime that is
+   constant for the whole run) so every model in a run computes the same
+   window and there is no drift across a UTC midnight boundary.
+
+   Usage:
+       {% set begin = microbatch_begin() %}
+       {% set meta_config = { "begin": begin, ... } %}
+#}
+{% macro microbatch_begin(default='2015-09-30') %}
+    {%- if target.name == 'ci' -%}
+        {%- set window_days = var('microbatch_ci_window_days', 30) | int -%}
+        {{ return((run_started_at - modules.datetime.timedelta(days=window_days)).strftime('%Y-%m-%d')) }}
+    {%- else -%}
+        {{ return(default) }}
+    {%- endif -%}
+{% endmacro %}

--- a/models/intermediate/account_balances/int_account_balances__contracts.yml
+++ b/models/intermediate/account_balances/int_account_balances__contracts.yml
@@ -33,6 +33,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
           - relationships:
               to: ref('int_asset_metadata')
               field: contract_id

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -1,17 +1,17 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {{ config(
     materialized='incremental',
     incremental_strategy='microbatch',
     event_time='day',
     batch_size=batch_size,
-    concurrent_batches=flags.FULL_REFRESH,
+    concurrent_batches=true,
     begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH
+        , "copy_partitions": true
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
 )}}

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.yml
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.yml
@@ -45,6 +45,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: balance
         description: '{{ doc("balance") }}'

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -1,17 +1,17 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {{ config(
     materialized='incremental',
     incremental_strategy='microbatch',
     event_time='day',
     batch_size=batch_size,
-    concurrent_batches=flags.FULL_REFRESH,
+    concurrent_batches=true,
     begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH
+        , "copy_partitions": true
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
     )

--- a/models/intermediate/account_balances/int_account_balances__offers.yml
+++ b/models/intermediate/account_balances/int_account_balances__offers.yml
@@ -45,6 +45,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: balance
         description: '{{ doc("balance") }}'

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin='2021-01-01',
+    begin=microbatch_begin('2021-01-01'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -1,17 +1,17 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {{ config(
     materialized='incremental',
     incremental_strategy='microbatch',
     event_time='day',
     batch_size=batch_size,
-    concurrent_batches=flags.FULL_REFRESH,
+    concurrent_batches=true,
     begin='2021-01-01',
     partition_by={
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH
+        , "copy_partitions": true
     },
     cluster_by=["asset_type", "asset_code", "asset_issuer"],
 ) }}

--- a/models/intermediate/reflector_prices/int_reflector_prices__sdex.yml
+++ b/models/intermediate/reflector_prices/int_reflector_prices__sdex.yml
@@ -26,17 +26,23 @@ models:
       - name: asset_issuer
         description: '{{ doc("asset_issuer") }}'
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_code
         description: '{{ doc("asset_code") }}'
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_type
         description: '{{ doc("asset_type") }}'
         tests:
-          - not_null
+          - not_null:
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_contract_id
         description: '{{ doc("asset_contract_id") }}'

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -1,17 +1,17 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "materialized": "incremental",
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2015-09-30",
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
 } %}
 
 {{ config(

--- a/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
+++ b/models/intermediate/tokens/transfers/int_token_transfer_enrichment.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "materialized": "incremental",
@@ -6,7 +7,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -6,13 +6,13 @@
     "incremental_strategy": "microbatch",
     "event_time": "day",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2022-08-08",
     "partition_by": {
         "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
     "tags": ["tvl"]
 } %}
 

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2022-08-08') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -7,7 +8,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2022-08-08",
+    "begin": begin,
     "partition_by": {
         "field": "day"
         , "data_type": "date"

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -6,13 +6,13 @@
     "incremental_strategy": "microbatch",
     "event_time": "day",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2022-08-08",
     "partition_by": {
         "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
     "tags": ["tvl"]
 } %}
 

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2022-08-08') %}
 
 {# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
 {% set meta_config = {
@@ -7,7 +8,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2022-08-08",
+    "begin": begin,
     "partition_by": {
         "field": "day"
         , "data_type": "date"

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2021-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2021-01-01",
+    "begin": begin,
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,13 +11,13 @@
     "incremental_strategy": "microbatch",
     "event_time": "day",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2021-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH
+        , "copy_partitions": true
     },
     "cluster_by": ["account_id", "contract_id"],
     "tags": ["asset_balance_agg", "account_balance_agg"],

--- a/models/marts/account_balances/account_balances__daily_agg.yml
+++ b/models/marts/account_balances/account_balances__daily_agg.yml
@@ -55,6 +55,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: liquidity_pool_balance
         description: '{{ doc("liquidity_pool_balance") }}'

--- a/models/marts/account_balances/account_balances__daily_agg.yml
+++ b/models/marts/account_balances/account_balances__daily_agg.yml
@@ -23,6 +23,8 @@ models:
             - contract_id
           date_column_name: "day"
           greater_than_equal_to: "2 day"
+          config:
+            severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Tests the uniqueness combination of: day, account_id, and contract_id."
     columns:

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2021-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2021-01-01",
+    "begin": begin,
     "partition_by": {
          "field": "day"
         , "data_type": "date"

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,13 +11,13 @@
     "incremental_strategy": "microbatch",
     "event_time": "day",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2021-01-01",
     "partition_by": {
          "field": "day"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH
+        , "copy_partitions": true
     },
     "tags": ["asset_balance_agg"],
 } %}

--- a/models/marts/asset_balances/asset_balances__daily_agg.yml
+++ b/models/marts/asset_balances/asset_balances__daily_agg.yml
@@ -46,6 +46,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "day"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: liquidity_pool_balance
         description: '{{ doc("liquidity_pool_balance") }}'

--- a/models/marts/daily_fee_stats_agg.sql
+++ b/models/marts/daily_fee_stats_agg.sql
@@ -5,8 +5,7 @@
         "min_match_percent": 98,
         "filters": {"column": "day_agg"},
     },
-    "materialized": "incremental",
-    "unique_key": ["day_agg"],
+    "materialized": "table",
     "tags": ["daily_fee_stats"],
     "cluster_by": ["day_agg"]
 } %}
@@ -21,11 +20,6 @@ with
     ledger_stats as (
         select *
         from {{ ref('ledger_fee_stats_agg') }}
-        where
-            day_agg < date('{{ var("batch_end_date") }}')
-            {% if is_incremental() %}
-                and day_agg >= date('{{ var("batch_start_date") }}')
-            {% endif %}
     )
 
     , final as (

--- a/models/marts/daily_fee_stats_agg.yml
+++ b/models/marts/daily_fee_stats_agg.yml
@@ -19,34 +19,24 @@ models:
       - name: day_agg
         description: '{{ doc("ledger_fee_day_agg") }}'
         tests:
-          - incremental_unique:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - unique
+          - not_null
 
       # General
       - name: total_fee_charged
         description: '{{ doc("ledger_fee_total_fee_charged") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: max_fee_charged
         description: '{{ doc("ledger_fee_max_fee_charged") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: txn_count
         description: '{{ doc("ledger_fee_txn_count") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: failed_txn_count
         description: '{{ doc("ledger_fee_failed_txn_count") }}'
@@ -54,37 +44,27 @@ models:
       - name: total_effective_txn_operation_count
         description: '{{ doc("ledger_fee_total_effective_txn_operation_count") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: total_raw_txn_operation_count
         description: '{{ doc("ledger_fee_total_raw_txn_operation_count") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: min_ledger_sequence
         description: '{{ doc("daily_fee_min_ledger_sequence") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: max_ledger_sequence
         description: '{{ doc("daily_fee_max_ledger_sequence") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: total_ledgers
         description: '{{ doc("daily_fee_total_ledgers") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "day_agg"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       # Classic: fee aggregates
       - name: classic_txn_count

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "cluster_by": ["ledger_sequence","transaction_id","op_account_id","type"],
     "partition_by": {
         "field": "closed_at"

--- a/models/marts/enriched_history/enriched_history_operations.sql
+++ b/models/marts/enriched_history/enriched_history_operations.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,14 +11,14 @@
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2015-09-30",
     "cluster_by": ["ledger_sequence","transaction_id","op_account_id","type"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
     "tags": ["enriched_history_operations"],
 } %}
 

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2024-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2024-01-01",
+    "begin": begin,
     "cluster_by": ["ledger_sequence", "transaction_id", "op_type"],
     "partition_by": {
         "field": "closed_at"

--- a/models/marts/enriched_history/enriched_history_operations_soroban.sql
+++ b/models/marts/enriched_history/enriched_history_operations_soroban.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,14 +11,14 @@
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2024-01-01",
     "cluster_by": ["ledger_sequence", "transaction_id", "op_type"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
     "tags": ["enriched_history_operations"],
 } %}
 

--- a/models/marts/evicted_keys.sql
+++ b/models/marts/evicted_keys.sql
@@ -5,9 +5,7 @@
         "min_match_percent": 98,
         "filters": {"column": "closed_at"},
     },
-    "materialized": "incremental",
-    "incremental_strategy": "merge",
-    "unique_key": ["ledger_key_hash", "closed_at"],
+    "materialized": "table",
     "tags": ["evicted_keys"]
 } %}
 
@@ -22,39 +20,19 @@ with
         select
             kh as ledger_key_hash
             , shl.closed_at
-            , shl.sequence as ledger_sequence
             , true as is_evicted
+            , shl.sequence as ledger_sequence
         from {{ ref('stg_history_ledgers') }} as shl
         cross join unnest(shl.evicted_ledger_keys_hash) as kh
-        where
-            true
-            -- Need to add/subtract one day to the window boundaries
-            -- because this model runs at 30 min increments.
-            -- Without the additional date buffering the following would occur
-            -- * batch_start_date == '2025-01-01 01:00:00' --> '2025-01-01'
-            -- * batch_end_date == '2025-01-01 01:30:00' --> '2025-01-01'
-            -- * '2025-01-01 <= closed_at < '2025-01-01' would never have any data to processes
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-            -- The extra day date_sub is useful in the case the first scheduled run for a day is skipped
-            -- because the DAG is configured with catchup=false
-            and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-    {% endif %}
     )
 
     , restored as (
         select
             ledger_key_hash
             , closed_at
-            , ledger_sequence
             , false as is_evicted
+            , ledger_sequence
         from {{ ref('stg_restored_key') }}
-        where
-            true
-            and closed_at < timestamp(date_add(date('{{ var("batch_end_date") }}'), interval 1 day))
-        {% if is_incremental() %}
-            and closed_at >= timestamp(date_sub(date('{{ var("batch_start_date") }}'), interval 1 day))
-    {% endif %}
     )
 
 select * from evicted

--- a/models/marts/evicted_keys.yml
+++ b/models/marts/evicted_keys.yml
@@ -15,32 +15,28 @@ models:
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - ledger_key_hash
+            - closed_at
 
     columns:
       - name: ledger_key_hash
         description: '{{ doc("ledger_key_hash") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "closed_at"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: closed_at
         description: '{{ doc("closed_at") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "closed_at"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: ledger_sequence
         description: '{{ doc("ledger_sequence") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "closed_at"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: is_evicted
         description: '{{ doc("is_evicted") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "closed_at"
-              greater_than_equal_to: "2 day"
+          - not_null

--- a/models/marts/history_assets.sql
+++ b/models/marts/history_assets.sql
@@ -4,8 +4,7 @@
         "exclude_columns": ["batch_id", "batch_run_date", "batch_insert_ts", "airflow_start_ts"],
         "min_match_percent": 98,
     },
-    "materialized": "incremental",
-    "unique_key": ["asset_id"],
+    "materialized": "table",
     "cluster_by": ["asset_id"],
     "tags": ["history_assets"]
 } %}
@@ -16,79 +15,28 @@
     )
 }}
 
-/* If the table is running incrementally, deduplicate assets and only add those that do not exist in the table */
-{% if is_incremental() %}
+/* Deduplicate all assets and generate the table */
+with
+    prep_dedup as (
+        select
+            *
+            , row_number() over (
+                partition by asset_id
+                order by batch_run_date asc
+            ) as dedup_grouping
+        from {{ ref('stg_history_assets') }}
+    )
 
-    /* This query selects the deduplicated assets from the new load */
-    with
-        new_load as (
-            select *
-            from {{ ref('stg_history_assets') }}
-        )
-
-        /* selects the deduplicated table for comparision */
-        , deduplicated_table as (
-            select *
-            from {{ this }}
-        )
-
-        /* excludes any assets from the load that already exist in the deduplicated table */
-        , exclude_duplicates as (
-            select
-                new_load.asset_id
-                , new_load.asset_code
-                , new_load.asset_issuer
-                , new_load.asset_type
-            from new_load
-            left join
-                deduplicated_table
-                on
-                new_load.asset_id = deduplicated_table.asset_id
-            where
-                deduplicated_table.asset_id is null
-        )
-
-        /* Adds only the new assets from the load to the assets table */
-        , add_assets as (
-            select
-                new_load.asset_id
-                , exclude_duplicates.asset_type
-                , exclude_duplicates.asset_code
-                , exclude_duplicates.asset_issuer
-                , new_load.batch_id
-                , new_load.batch_run_date
-            from exclude_duplicates
-            left join
-                new_load on
-            exclude_duplicates.asset_id = new_load.asset_id
-        )
-
-{% else %}
-    /* If the table is being run in full-refresh mode, deduplicate all assets and generate table */
-
-    with
-        prep_dedup as (
-            select
-                *
-                , row_number() over (
-                    partition by asset_id
-                    order by batch_run_date asc
-                ) as dedup_grouping
-            from {{ ref('stg_history_assets') }}
-        )
-
-        , add_assets as (
-            select
-                asset_id
-                , asset_type
-                , asset_code
-                , asset_issuer
-                , batch_id
-                , batch_run_date
-            from prep_dedup
-        )
-
-{% endif %}
+    , add_assets as (
+        select
+            asset_id
+            , asset_type
+            , asset_code
+            , asset_issuer
+            , batch_id
+            , batch_run_date
+        from prep_dedup
+    )
 
 select
     *

--- a/models/marts/history_assets.yml
+++ b/models/marts/history_assets.yml
@@ -15,59 +15,45 @@ models:
             severity: '{{ "error" if target.name == "prod" else "warn" }}'
           meta:
             description: "Monitors the freshness of your table over time, as the expected time between data updates."
-      - incremental_unique_combination_of_columns:
+      - dbt_utils.unique_combination_of_columns:
           combination_of_columns:
             - asset_type
             - asset_code
             - asset_issuer
-          date_column_name: "batch_run_date"
-          greater_than_equal_to: "2 day"
     columns:
       - name: asset_id
         description: '{{ doc("assets_id") }}'
         tests:
-          - incremental_unique:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
+          - unique
+          - not_null
 
       - name: asset_type
         description: '{{ doc("asset_type") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
+          - not_null
           - accepted_values:
               values: ["credit_alphanum12", "credit_alphanum4", "native"]
 
       - name: asset_code
         description: '{{ doc("asset_code") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
-              condition: 'asset_type != "native"'
+          - not_null:
+              config:
+                where: 'asset_type != "native"'
 
       - name: asset_issuer
         description: '{{ doc("asset_issuer") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
-              condition: 'asset_type != "native"'
+          - not_null:
+              config:
+                where: 'asset_type != "native"'
 
       - name: batch_id
         description: '{{ doc("batch_id") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
+          - not_null
 
       - name: batch_run_date
         description: '{{ doc("batch_run_date") }}'
         tests:
-          - incremental_not_null:
-              date_column_name: "batch_run_date"
-              greater_than_equal_to: "2 day"
+          - not_null

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,7 +11,7 @@
     "incremental_strategy": "microbatch",
     "event_time": "hour_agg",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2015-09-30",
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "fee_source_account"],
@@ -19,7 +19,7 @@
         "field": "hour_agg",
         "data_type": "timestamp",
         "granularity": "day",
-        "copy_partitions": flags.FULL_REFRESH
+        "copy_partitions": true
     },
 } %}
 

--- a/models/marts/hourly_fee_agg_account.sql
+++ b/models/marts/hourly_fee_agg_account.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "hour_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "fee_source_account"],
     "partition_by": {

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2024-01-01') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "hour_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2024-01-01",
+    "begin": begin,
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "contract_id"],
     "partition_by": {

--- a/models/marts/hourly_soroban_fee_agg_contract.sql
+++ b/models/marts/hourly_soroban_fee_agg_contract.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,7 +11,7 @@
     "incremental_strategy": "microbatch",
     "event_time": "hour_agg",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2024-01-01",
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["hour_agg", "contract_id"],
@@ -19,7 +19,7 @@
         "field": "hour_agg",
         "data_type": "timestamp",
         "granularity": "day",
-        "copy_partitions": flags.FULL_REFRESH
+        "copy_partitions": true
     },
 } %}
 

--- a/models/marts/ledger_current_state/account_signers_current.sql
+++ b/models/marts/ledger_current_state/account_signers_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "unique_id",
     "cluster_by": "account_id",
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/accounts_current.sql
+++ b/models/marts/ledger_current_state/accounts_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "account_id",
     "tags": ["current_state"]
 } %}

--- a/models/marts/ledger_current_state/claimable_balances_current.sql
+++ b/models/marts/ledger_current_state/claimable_balances_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "balance_id",
     "tags": ["current_state"]
 } %}

--- a/models/marts/ledger_current_state/config_settings_current.sql
+++ b/models/marts/ledger_current_state/config_settings_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "config_setting_id",
     "tags": ["current_state"]
 } %}

--- a/models/marts/ledger_current_state/contract_code_current.sql
+++ b/models/marts/ledger_current_state/contract_code_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": ["contract_code_hash"],
     "cluster_by": ["contract_code_hash"],
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/contract_data_current.sql
+++ b/models/marts/ledger_current_state/contract_data_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": ["unique_id"],
     "cluster_by": ["contract_id"],
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/liquidity_pools_current.sql
+++ b/models/marts/ledger_current_state/liquidity_pools_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "liquidity_pool_id",
     "cluster_by": ["asset_a_code", "asset_a_issuer", "asset_b_code", "asset_b_issuer"],
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/offers_current.sql
+++ b/models/marts/ledger_current_state/offers_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "offer_id",
     "cluster_by": ["selling_asset_code", "selling_asset_issuer", "buying_asset_code", "buying_asset_issuer"],
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/trust_lines_current.sql
+++ b/models/marts/ledger_current_state/trust_lines_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": "unique_id",
     "cluster_by": ["asset_code", "asset_issuer"],
     "tags": ["current_state"]

--- a/models/marts/ledger_current_state/ttl_current.sql
+++ b/models/marts/ledger_current_state/ttl_current.sql
@@ -1,5 +1,6 @@
 {% set meta_config = {
     "materialized": "incremental",
+    "incremental_strategy": "merge",
     "unique_key": ["key_hash"],
     "cluster_by": ["key_hash"],
     "tags": ["current_state"]

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "day_agg",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "partition_by": {
         "field": "day_agg"
         , "data_type": "date"

--- a/models/marts/ledger_fee_stats_agg.sql
+++ b/models/marts/ledger_fee_stats_agg.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,13 +11,13 @@
     "incremental_strategy": "microbatch",
     "event_time": "day_agg",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2015-09-30",
     "partition_by": {
         "field": "day_agg"
         , "data_type": "date"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH},
+        , "copy_partitions": true},
     "tags": ["hourly_fee_stats"],
     "cluster_by": ["day_agg", "ledger_sequence"]
 } %}

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,4 +1,4 @@
-{% set batch_size = 'year' if flags.FULL_REFRESH else 'day' %}
+{% set batch_size = microbatch_batch_size() %}
 
 {% set meta_config = {
     "datadiff": {
@@ -11,14 +11,14 @@
     "incremental_strategy": "microbatch",
     "event_time": "closed_at",
     "batch_size": batch_size,
-    "concurrent_batches": flags.FULL_REFRESH,
+    "concurrent_batches": true,
     "begin": "2015-09-30",
     "tags": ["token_transfer"],
     "partition_by": {
         "field": "closed_at"
         , "data_type": "timestamp"
         , "granularity": "day"
-        , "copy_partitions": flags.FULL_REFRESH}
+        , "copy_partitions": true}
 } %}
 
 {{ config(

--- a/models/marts/tokens/transfers/token_transfers.sql
+++ b/models/marts/tokens/transfers/token_transfers.sql
@@ -1,4 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {
@@ -12,7 +13,7 @@
     "event_time": "closed_at",
     "batch_size": batch_size,
     "concurrent_batches": true,
-    "begin": "2015-09-30",
+    "begin": begin,
     "tags": ["token_transfer"],
     "partition_by": {
         "field": "closed_at"

--- a/models/snapshots/reflector_prices_data_sdex_snapshot.yml
+++ b/models/snapshots/reflector_prices_data_sdex_snapshot.yml
@@ -28,6 +28,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "valid_from"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_type
         description: '{{ doc("asset_type") }}'
@@ -35,6 +37,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "valid_from"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_issuer
         description: '{{ doc("asset_issuer") }}'
@@ -42,6 +46,8 @@ models:
           - stellar_dbt_public.incremental_not_null:
               date_column_name: "valid_from"
               greater_than_equal_to: "2 day"
+              config:
+                severity: '{{ "error" if target.name == "prod" else "warn" }}'
 
       - name: asset_contract_id
         description: '{{ doc("asset_contract_id") }}'

--- a/models/sources/src_accounts.yml
+++ b/models/sources/src_accounts.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: accounts
         description: '{{ doc("accounts") }}'

--- a/models/sources/src_accounts_signers.yml
+++ b/models/sources/src_accounts_signers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: account_signers
         description: '{{ doc("accounts_signers") }}'

--- a/models/sources/src_claimable_balances.yml
+++ b/models/sources/src_claimable_balances.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: claimable_balances
         description: '{{ doc("claimable_balances") }}'

--- a/models/sources/src_config_settings.yml
+++ b/models/sources/src_config_settings.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: config_settings
         description: '{{ doc("config_settings") }}'

--- a/models/sources/src_contract_code.yml
+++ b/models/sources/src_contract_code.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: contract_code
         description: '{{ doc("contract_code") }}'

--- a/models/sources/src_contract_data.yml
+++ b/models/sources/src_contract_data.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: contract_data
         description: '{{ doc("contract_data") }}'

--- a/models/sources/src_history_assets.yml
+++ b/models/sources/src_history_assets.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_assets_staging
         description: '{{ doc("history_assets_staging") }}'

--- a/models/sources/src_history_contract_events.yml
+++ b/models/sources/src_history_contract_events.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_contract_events
         description: '{{ doc("history_contract_events") }}'

--- a/models/sources/src_history_effects.yml
+++ b/models/sources/src_history_effects.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_effects
         description: '{{ doc("history_effects") }}'

--- a/models/sources/src_history_ledgers.yml
+++ b/models/sources/src_history_ledgers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_ledgers
         description: '{{ doc("history_ledgers") }}'

--- a/models/sources/src_history_operations.yml
+++ b/models/sources/src_history_operations.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_operations
         description: '{{ doc("history_operations") }}'

--- a/models/sources/src_history_trades.yml
+++ b/models/sources/src_history_trades.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_trades
         description: '{{ doc("history_trades") }}'

--- a/models/sources/src_history_transactions.yml
+++ b/models/sources/src_history_transactions.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: history_transactions
         description: '{{ doc("history_transactions") }}'

--- a/models/sources/src_liquidity_pools.yml
+++ b/models/sources/src_liquidity_pools.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: liquidity_pools
         description: '{{ doc("liquidity_pools") }}'

--- a/models/sources/src_offers.yml
+++ b/models/sources/src_offers.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: offers
         description: '{{ doc("liquidity_pools") }}'

--- a/models/sources/src_restored_key.yml
+++ b/models/sources/src_restored_key.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: restored_key
         description: '{{ doc("restored_key") }}'

--- a/models/sources/src_token_transfers_raw.yml
+++ b/models/sources/src_token_transfers_raw.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: token_transfers_raw
         description: '{{ doc("token_transfers_raw") }}'

--- a/models/sources/src_trust_lines.yml
+++ b/models/sources/src_trust_lines.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: trust_lines
         description: '{{ doc("trust_lines") }}'

--- a/models/sources/src_ttl.yml
+++ b/models/sources/src_ttl.yml
@@ -2,7 +2,8 @@ version: 2
 
 sources:
   - name: crypto_stellar
-    database: "crypto-stellar"
+    database: "{{ env_var('PUBLIC_SOURCE_DB', 'test-hubble-319619' if target.name in ('ci', 'test') else 'crypto-stellar') }}"
+    schema: "{{ env_var('PUBLIC_SOURCE_SCHEMA', 'test_crypto_stellar' if target.name in ('ci', 'test') else 'crypto_stellar') }}"
     tables:
       - name: ttl
         description: '{{ doc("ttl") }}'


### PR DESCRIPTION
Release v20260804 for stellar-dbt-public.

## What's in this release

- **Tune incremental strategies** (#302, pairs with stellar-dbt #1033): converts the last set of incremental merge models to microbatch / insert_overwrite / table; batch size configurable for partial refreshes.
- **Env-driven sources + CI windows** (#308): source database/schema resolved from env vars; `microbatch_begin()` macro for CI batch windows.

Merging auto-tags the next release; stellar-dbt's `packages.yml` gets repinned from the `release-v20260804` branch to that tag before the stellar-dbt release PR merges.
