### PR TITLE
Set 2015-09-30 start date for account balance, TVL, and liquidity pool snapshot models

### DIFF
--- a/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
+++ b/models/intermediate/account_balances/int_account_balances__liquidity_pools.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin=microbatch_begin('2021-01-01'),
+    begin=microbatch_begin('2015-09-30'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__offers.sql
+++ b/models/intermediate/account_balances/int_account_balances__offers.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin=microbatch_begin('2021-01-01'),
+    begin=microbatch_begin('2015-09-30'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/account_balances/int_account_balances__trustlines.sql
+++ b/models/intermediate/account_balances/int_account_balances__trustlines.sql
@@ -6,7 +6,7 @@
     event_time='day',
     batch_size=batch_size,
     concurrent_batches=true,
-    begin=microbatch_begin('2021-01-01'),
+    begin=microbatch_begin('2015-09-30'),
     partition_by={
          "field": "day"
         , "data_type": "date"

--- a/models/intermediate/tvl/int_tvl_accounts.sql
+++ b/models/intermediate/tvl/int_tvl_accounts.sql
@@ -1,7 +1,7 @@
 {% set batch_size = microbatch_batch_size() %}
-{% set begin = microbatch_begin('2022-08-08') %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
-{# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
+{# `begin` matches accounts_snapshot's start date (2015-09-30). #}
 {% set meta_config = {
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/intermediate/tvl/int_tvl_trustlines.sql
+++ b/models/intermediate/tvl/int_tvl_trustlines.sql
@@ -1,7 +1,7 @@
 {% set batch_size = microbatch_batch_size() %}
-{% set begin = microbatch_begin('2022-08-08') %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
-{# `begin` is 2022-08-08: the earliest asset pricing data from stellar.expert. #}
+{# `begin` matches trustlines_snapshot's start date (2015-09-30). #}
 {% set meta_config = {
     "materialized": "incremental",
     "incremental_strategy": "microbatch",

--- a/models/marts/account_balances/account_balances__daily_agg.sql
+++ b/models/marts/account_balances/account_balances__daily_agg.sql
@@ -1,5 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
-{% set begin = microbatch_begin('2021-01-01') %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/marts/asset_balances/asset_balances__daily_agg.sql
+++ b/models/marts/asset_balances/asset_balances__daily_agg.sql
@@ -1,5 +1,5 @@
 {% set batch_size = microbatch_batch_size() %}
-{% set begin = microbatch_begin('2021-01-01') %}
+{% set begin = microbatch_begin('2015-09-30') %}
 
 {% set meta_config = {
     "datadiff": {

--- a/models/snapshots/liquidity_pools_snapshot.sql
+++ b/models/snapshots/liquidity_pools_snapshot.sql
@@ -1,7 +1,7 @@
 -- depends_on: {{ ref('stg_liquidity_pools') }}
 {%- set temp_source_table = this.table ~ '_source' -%}
 {%- set temp_target_table = this.table ~ '_target' -%}
-{%- set snapshot_default_start_date = snapshot_begin('2021-11-01') -%}
+{%- set snapshot_default_start_date = snapshot_begin('2015-09-30') -%}
 
 {% set meta_config = {
     "datadiff": {


### PR DESCRIPTION
## Summary
- Set backfill start date to `2015-09-30` for:
  - `account_balances__daily_agg`
  - `asset_balances__daily_agg`
  - `int_account_balances__trustlines`
  - `int_account_balances__offers`
  - `int_account_balances__liquidity_pools`
  - `int_tvl_trustlines`
  - `int_tvl_accounts`
  - `liquidity_pools_snapshot`
- Updated the stale rationale comment on `int_tvl_trustlines`/`int_tvl_accounts` (previously referenced stellar.expert asset pricing data, which isn't actually used by these models) to instead reflect the new date matching `trustlines_snapshot`/`accounts_snapshot`.

## Test plan
- [ ] CI sqlfluff/dbt-checkpoint lint passes
- [ ] Backfill run confirmed to cover data from 2015-09-30 without errors