### PR TITLE
Tag every snapshot model with tag:snapshots

### DIFF
--- a/models/snapshots/accounts_snapshot.sql
+++ b/models/snapshots/accounts_snapshot.sql
@@ -30,7 +30,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_accounts"]
+    "tags": ["custom_snapshot_accounts", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/contract_data_snapshot.sql
+++ b/models/snapshots/contract_data_snapshot.sql
@@ -30,7 +30,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_contract_data"]
+    "tags": ["custom_snapshot_contract_data", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/evicted_keys_snapshot.sql
+++ b/models/snapshots/evicted_keys_snapshot.sql
@@ -30,7 +30,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_evicted_keys"]
+    "tags": ["custom_snapshot_evicted_keys", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/liquidity_pools_snapshot.sql
+++ b/models/snapshots/liquidity_pools_snapshot.sql
@@ -30,7 +30,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_liquidity_pools"]
+    "tags": ["custom_snapshot_liquidity_pools", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/reflector_prices_data_cex_snapshot.sql
+++ b/models/snapshots/reflector_prices_data_cex_snapshot.sql
@@ -25,7 +25,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_reflector_prices_data"]
+    "tags": ["custom_snapshot_reflector_prices_data", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/reflector_prices_data_fex_snapshot.sql
+++ b/models/snapshots/reflector_prices_data_fex_snapshot.sql
@@ -25,7 +25,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_reflector_prices_data"]
+    "tags": ["custom_snapshot_reflector_prices_data", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/reflector_prices_data_sdex_snapshot.sql
+++ b/models/snapshots/reflector_prices_data_sdex_snapshot.sql
@@ -25,7 +25,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_reflector_prices_data"]
+    "tags": ["custom_snapshot_reflector_prices_data", "snapshots"]
 } %}
 
 {{ config(

--- a/models/snapshots/trustlines_snapshot.sql
+++ b/models/snapshots/trustlines_snapshot.sql
@@ -36,7 +36,7 @@
     "valid_from_col_name": 'valid_from',
     "valid_to_col_name": 'valid_to',
     "on_schema_change": 'append_new_columns',
-    "tags": ["custom_snapshot_trustline"]
+    "tags": ["custom_snapshot_trustline", "snapshots"]
 } %}
 
 {{ config(


### PR DESCRIPTION
## Summary
- Appends `"snapshots"` to the `tags` list in all 8 snapshot models under `models/snapshots/` (accounts, contract_data, evicted_keys, liquidity_pools, reflector_prices_data_{cex,fex,sdex}, trustlines).
- Matches the convention already established in `stellar-dbt`, where all 3 snapshot models there already carry this tag.
- Lets selectors (e.g. `tag:snapshots`) and downstream DAGs target every snapshot model without enumerating them by name.

## Test plan
- [ ] `dbt ls --select tag:snapshots` resolves all 8 models
- [ ] `dbt build --select tag:snapshots` runs cleanly against a dev target