### PR TITLE
Fix unmapped newly priced assets on reflector by using the ordered assets list

### DIFF
--- a/.github/workflows/socket-scan.yml
+++ b/.github/workflows/socket-scan.yml
@@ -27,7 +27,7 @@ name: Socket reachability scan
 
 on:
   schedule:
-    - cron: '48 12 * * 0'
+    - cron: "48 12 * * 0"
   workflow_dispatch:
 
 permissions:

--- a/models/intermediate/reflector_prices/int_reflector_prices__sdex.sql
+++ b/models/intermediate/reflector_prices/int_reflector_prices__sdex.sql
@@ -31,16 +31,23 @@
 */
 
 with
+    -- The oracle's asset registry is the ordered `assets` vec in its instance
+    -- storage: an asset's position in the vec IS the asset_index the price
+    -- entries use. The contract also carries older per-asset address -> u32
+    -- entries, but those stopped being maintained (frozen at index 48 while
+    -- SolvBTC/PYUSD were appended to the vec as indices 49/50 on 2026-09-04),
+    -- so the vec is the only complete source.
     asset_coding as (
         select distinct
-            json_extract_scalar(storage_item, '$.key.address') as asset_contract_id
-            , cast(json_extract_scalar(storage_item, '$.val.u32') as int) as asset_index
+            json_extract_scalar(asset_entry, '$.vec[1].address') as asset_contract_id
+            , asset_index
         from {{ ref('contract_data_snapshot') }}
         , unnest(json_extract_array(val_decoded, '$.contract_instance.storage')) as storage_item
+        , unnest(json_extract_array(storage_item, '$.val.vec')) as asset_entry with offset as asset_index
         where
             contract_id = 'CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M'
             and contract_durability = 'ContractDataDurabilityPersistent'
-            and json_extract_scalar(storage_item, '$.key.address') is not null
+            and json_extract_scalar(storage_item, '$.key.string') = 'assets'
             and valid_to is null -- fetch only latest entry
     )
 
@@ -83,7 +90,7 @@ with
             , asset_index
             , cast(json_extract_scalar(prices_array[safe_offset(vec_index)], '$.i128') as float64) as price
         from new_format_raw
-            , unnest({{ find_changed_asset_indexes('mask_hex') }}) as asset_index with offset as vec_index
+        , unnest({{ find_changed_asset_indexes('mask_hex') }}) as asset_index with offset as vec_index
     )
 
     , price_data as (
@@ -92,11 +99,21 @@ with
         select * from price_data_new_format
     )
 
+    -- Contract tokens (no SAC) carry no usable code/type/issuer in stg_assets
+    -- (NULLs or empty strings); name them from int_asset_metadata and follow the
+    -- assets-mart convention for the rest: asset_type 'contract', asset_issuer ''
+    -- (empty, not null).
     , joined as (
         select distinct
-            stg_assets.asset_code
-            , stg_assets.asset_type
-            , stg_assets.asset_issuer
+            coalesce(nullif(stg_assets.asset_code, ''), iam.asset_code) as asset_code
+            , case
+                when nullif(stg_assets.asset_type, '') is not null then stg_assets.asset_type
+                when iam.contract_id is not null then 'contract'
+            end as asset_type
+            , case
+                when nullif(stg_assets.asset_type, '') is not null then stg_assets.asset_issuer
+                when iam.contract_id is not null then ''
+            end as asset_issuer
             , asset_coding.asset_contract_id
             , price_data.closed_at as updated_at
             , price_data.price * power(10, -14) as price
@@ -105,6 +122,8 @@ with
             on price_data.asset_index = asset_coding.asset_index
         left join {{ ref('stg_assets') }} as stg_assets
             on asset_coding.asset_contract_id = stg_assets.asset_contract_id
+        left join {{ ref('int_asset_metadata') }} as iam
+            on asset_coding.asset_contract_id = iam.contract_id
     )
 
     -- Calculate daily OHLC prices from the raw price data

--- a/tests/reflector_sdex_vec_matches_index_entries.sql
+++ b/tests/reflector_sdex_vec_matches_index_entries.sql
@@ -1,0 +1,68 @@
+-- The SDEX reflector model maps prices to assets positionally: an asset's position
+-- in the oracle's `assets` vec IS its price-feed index. The contract also still
+-- carries its older per-asset address -> u32 index entries; those stopped being
+-- maintained at index 48, but wherever one exists it is order-independent ground
+-- truth. This test cross-checks every legacy entry against the vec position, so a
+-- reordered or truncated vec -- which would silently attribute prices to the wrong
+-- (non-null) assets -- fails loudly instead. Known limits: if Reflector deletes the
+-- legacy entries the comparison set is empty and this passes trivially, and assets
+-- beyond index 48 have no legacy entry to check.
+
+-- Strictly use enabled condition to restrict singular tests from running in dbt build tasks.
+-- https://github.com/stellar/stellar-dbt-public/pull/95
+{{ config(
+    severity=("error" if target.name == "prod" else "warn")
+    , tags=["singular_test"]
+    , enabled=var("is_singular_airflow_task") == "true"
+    , meta={"alert_suppression_interval": 24, "exception_scope": {"entity_columns": ['asset_index'], "allows_day_scope": false}}
+    )
+}}
+
+with
+    legacy_entries as (
+        select distinct
+            json_extract_scalar(storage_item, '$.key.address') as asset_contract_id
+            , cast(json_extract_scalar(storage_item, '$.val.u32') as int) as asset_index
+        from {{ ref('contract_data_snapshot') }}
+        , unnest(json_extract_array(val_decoded, '$.contract_instance.storage')) as storage_item
+        where
+            contract_id = 'CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M'
+            and contract_durability = 'ContractDataDurabilityPersistent'
+            and json_extract_scalar(storage_item, '$.key.address') is not null
+            and valid_to is null -- fetch only latest entry
+    )
+
+    , vec_positions as (
+        select distinct
+            json_extract_scalar(asset_entry, '$.vec[1].address') as asset_contract_id
+            , asset_index
+        from {{ ref('contract_data_snapshot') }}
+        , unnest(json_extract_array(val_decoded, '$.contract_instance.storage')) as storage_item
+        , unnest(json_extract_array(storage_item, '$.val.vec')) as asset_entry with offset as asset_index
+        where
+            contract_id = 'CALI2BYU2JE6WVRUFYTS6MSBNEHGJ35P4AVCZYF3B6QOE3QKOB2PLE6M'
+            and contract_durability = 'ContractDataDurabilityPersistent'
+            and json_extract_scalar(storage_item, '$.key.string') = 'assets'
+            and valid_to is null -- fetch only latest entry
+    )
+
+select
+    legacy_entries.asset_index
+    , legacy_entries.asset_contract_id as legacy_contract_id
+    , vec_positions.asset_contract_id as vec_contract_id
+    , case
+        when vec_positions.asset_contract_id is null then 'index_missing_from_vec'
+        else 'contract_mismatch_at_index'
+    end as failure_reason
+from legacy_entries
+left join vec_positions
+    on legacy_entries.asset_index = vec_positions.asset_index
+where
+    (
+        vec_positions.asset_contract_id is null
+        or legacy_entries.asset_contract_id != vec_positions.asset_contract_id
+    )
+    {{ exclude_test_exceptions(
+        ref('public_test_exceptions')
+        , entity_columns={'asset_index': 'legacy_entries.asset_index'}
+    ) }}


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
      otherwise).
- [ ] This PR's title starts with the jira ticket associated with the PR.

### Thoroughness

- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.

### Release planning

- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
</details>

### What

**Maps Reflector SDEX oracle assets from the contract's ordered `assets` list instead of its per-asset `address → u32` index entries**, and names contract tokens from `int_asset_metadata` (following the assets-mart convention: `asset_type = 'contract'`, `asset_issuer = ''`) since `stg_assets` carries no identity for them.

### Why

On 2026-09-04 15:15 UTC Reflector added two assets to its SDEX price feed — **SolvBTC (index 49)** and **PYUSD (index 50)** — but only appended them to the `assets` list. The `address → u32` entries this model builds its index mapping from were never written; they've been frozen at index 48 through every storage capture we have, so they're a dead structure the current contract no longer maintains.

Result: prices for indices 49/50 arrive unmappable, the model emits them as one NULL-identity row (both assets pooled, close ≈ $1.00 — PYUSD's last tick), and the `not_null` tests on `int_reflector_prices__sdex` fail in prod and staging. The failure blocks `reflector_prices_data_sdex_snapshot`, so every reflector-only-priced asset (XRP, KALE, XRF, FIDR) has been serving frozen prices since Sep 4.

The `assets` list is the copy Reflector actually maintains: position in the list = asset index, verified exact against all 49 previously-mapped assets (zero disagreements). It also self-heals — the next asset Reflector adds maps automatically.

Validated against live prod data: 47,812 ticks → zero NULL identity columns; SolvBTC lands as `('SolvBTC', 'contract', '')` at $77.5k–$80k, PYUSD as a normal classic asset at ~$1.00; existing assets byte-identical.


### Known limitations

[TODO or N/A]
