### PR TITLE
Allow org members to invoke @claude

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,18 +18,22 @@ jobs:
       (github.event_name == 'issue_comment' &&
         contains(github.event.comment.body, '@claude') &&
         (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request_review_comment' &&
         contains(github.event.comment.body, '@claude') &&
         (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
          github.event.comment.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'pull_request_review' &&
         contains(github.event.review.body, '@claude') &&
         (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
          github.event.review.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'issues' &&
         (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
         (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
          github.event.issue.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Problem

`@claude` has never worked in this repo. Zero successful `claude.yml` runs since it was installed, while the five sibling repos have working runs.

The cause is the job's `if:` gate, which accepts only `OWNER` and `COLLABORATOR`. `author_association` returns a **single highest-precedence value** (`OWNER > MEMBER > COLLABORATOR > CONTRIBUTOR > NONE`), and org membership outranks collaborator. So everyone on the data team is reported as `MEMBER` despite holding write access, fails the gate, and the run is skipped.

A skipped job posts nothing back and never shows red, which is why this went unnoticed.

Reproduced today on stellar-dbt-public#321:

```
comment  18:00:28Z  chowbao  author_association=MEMBER  contains @claude
run      18:00:35Z  event=issue_comment  conclusion=skipped
run      18:00:25Z  event=issues         conclusion=skipped
```

## Change

Adds `MEMBER` to the four trigger clauses (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`).

The file is now **byte-identical** to the workflow already running in `stellar-dbt`, `stellar-etl-internal`, `stellar-etl-airflow`, `datafold-monitors` and `hubble` (blob `6e3805f4`).

## Access impact

This repo is public, so the gate matters. It does not open up:

| author_association | Who | Before | After |
|---|---|---|---|
| `OWNER` | repo owner | allowed | allowed |
| `MEMBER` | `stellar` org, provisioned via enterprise SAML SSO | **blocked** | allowed |
| `COLLABORATOR` | write, non-org-member | allowed | allowed |
| `CONTRIBUTOR` | has merged a PR | blocked | blocked |
| `FIRST_TIME_CONTRIBUTOR` / `NONE` | general public | blocked | blocked |

The public stays excluded. Anthropic auth is unchanged: still WIF/OIDC via the `ANTHROPIC_*` secrets, no API key.
