### PR TITLE
Add DEVELOPING.md and CONTRIBUTING.md, trim README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,151 @@
+# Contributing to stellar-dbt-public
+
+Thanks for taking the time to improve stellar-dbt-public!
+
+The following is a set of guidelines for contributions and may change over
+time. Feel free to suggest improvements to this document in a pull request.
+
+Start with the [Stellar Contribution Guide](https://github.com/stellar/.github/blob/master/CONTRIBUTING.md),
+which applies to every Stellar project. For instructions on setting up the
+project and running models and tests, see [DEVELOPING.md](DEVELOPING.md).
+
+## Table of Contents
+
+- [Branches](#branches)
+- [Commit messages](#commit-messages)
+- [Pull requests](#pull-requests)
+- [Issues](#issues)
+- [Releases](#releases)
+- [SQL style](#sql-style)
+- [Model conventions](#model-conventions)
+- [Documentation](#documentation)
+- [Security](#security)
+
+## Branches
+
+Before creating a branch it is important to know whether your change is a
+release (breaking changes), a feature (functionality) or a patch (a bug fix).
+With that information, name your branch like this:
+
+- `major/<branch-name>`
+- `minor/<branch-name>`
+- `patch/<branch-name>`
+
+If the branch already exists, rename it _before opening the pull request_.
+
+The prefix is not just a convention: the release workflow reads it to decide
+which part of the version to increment when your pull request merges. See
+[Releases](#releases).
+
+## Commit messages
+
+- Use the present tense ("Add model" not "Added model").
+- Use the imperative mood ("Move filter to..." not "Moves filter to...").
+- Keep the subject line short and put context in the body.
+
+## Pull requests
+
+Open pull requests against `master`, or against the active `release*` branch if
+the change belongs to a release already in flight.
+
+The [pull request template](.github/pull_request_template.md) asks you to fill
+in **What**, **Why**, and **Known limitations**. The "Why" matters most — include
+enough context that a reviewer who has not seen the issue can follow the change.
+
+- Keep scope narrow. Aim for something a reviewer can get through in about 20
+  minutes; break bigger work into a series of pull requests.
+- Do not mix refactoring with feature work. Refactoring pull requests touch far
+  more code and get reviewed in less detail, so keep them separate.
+- Add tests for new models and for the behavior a fix restores. A new mart model
+  needs at least a uniqueness and a not-null test on its key.
+- Run `pre-commit run --all-files` before pushing, and fix everything it
+  reports.
+- Say in the description whether the change alters existing output. A model
+  whose columns or grain change is a breaking change for downstream consumers,
+  and belongs on a `major/` branch.
+- Update [DEVELOPING.md](DEVELOPING.md) or the [README](README.md) when you
+  change how the project is set up, run, or laid out.
+
+## Issues
+
+- Label issues with `bug` if they are clearly a bug, and `feature request` if
+  they are a feature request.
+- For a data issue, include the model name, the dates or ledger range affected,
+  and the query that shows the problem.
+
+## Releases
+
+This project is consumed as a dbt package, so every merge is a release.
+Merging a pull request into `master` tags a new version and publishes a GitHub
+release automatically. The version bump comes from your **branch prefix**:
+
+| Branch prefix | Version bump | Use for                                         |
+| ------------- | ------------ | ----------------------------------------------- |
+| `major/`      | major        | Incompatible changes                            |
+| `minor/`      | minor        | New functionality, backward compatible          |
+| anything else | patch        | Backward-compatible bug fixes and documentation |
+
+Note that a branch with no recognized prefix still produces a patch release, so
+a breaking change on a mis-named branch gets an incorrect version. Rename the
+branch before opening the pull request.
+
+Because downstream projects pin this package by tag in their `packages.yml`,
+merging here does not by itself ship your change to any consumer. A consumer
+picks it up only after bumping its pin and running `dbt deps`.
+
+## SQL style
+
+- SQL is linted by [sqlfluff](https://docs.sqlfluff.com/) using the BigQuery
+  dialect and the dbt templater. The rules live in [.sqlfluff](.sqlfluff).
+- The `CI Linting` check runs `diff-quality` over the lines your branch changed
+  and fails below a score of 95. It scores only your changed lines, so a file
+  with pre-existing violations can pass while your new lines fail. Run
+  `sqlfluff lint` on the files you touched before pushing.
+- Reference other models with `{{ ref('model_name') }}` and raw tables with
+  `{{ source('source_name', 'table_name') }}`, never with a hardcoded
+  `project.dataset.table`.
+
+## Model conventions
+
+- Put the model in the right layer, and follow that layer's rules. See
+  [Project structure](DEVELOPING.md#project-structure).
+- Prefix staging models `stg_` and intermediate models `int_`, and match the
+  naming of the models already in that directory: staging models are named for
+  the source table they read (`stg_history_transactions`), and intermediate
+  models use `int_<subject>__<detail>` when a subject has several models
+  (`int_account_balances__trustlines`). Mart models are named for the entity
+  they describe, with no prefix.
+- Every model gets a co-located `.yml` of the same name, with a description for
+  the model and for each of its columns. Marts additionally require every
+  column to be described — an undescribed mart column is a review comment, and
+  the project evaluator check tracks documentation coverage.
+- Reuse an existing doc block for a column that already means the same thing
+  elsewhere, rather than writing a new description. See
+  [Documentation](#documentation).
+- Prefer the project's date-scoped generic tests
+  (`incremental_not_null`, `incremental_unique`, and friends in
+  `tests/generic/`) over the stock dbt equivalents on incremental models, so a
+  test checks the batch window rather than scanning the whole table.
+- Do not disable a test to silence a known, accepted failure. Add a row to
+  `seeds/public_test_exceptions.csv` instead, and read
+  [docs/test_exceptions.md](docs/test_exceptions.md) first.
+
+## Documentation
+
+- Shared column descriptions live in `models/docs/universal.md` and are
+  referenced as `{{ doc('column_name') }}`. Domain-specific blocks live in
+  `models/docs/sources/`, `models/docs/intermediate/`, `models/docs/marts/`, and
+  `models/docs/snapshots/`.
+- Setup, running, testing, and layer guidance belong in
+  [DEVELOPING.md](DEVELOPING.md).
+- Contribution process, style, and release mechanics belong here.
+- The published docs site is regenerated from `master` on every merge, so a
+  missing description ships as a gap in public documentation.
+
+## Security
+
+This repository is **excluded** from the Stellar bug bounty program; see
+[SECURITY.md](SECURITY.md). Please still avoid opening a public issue for a
+suspected vulnerability — follow the
+[Stellar security policy](https://github.com/stellar/.github/blob/master/SECURITY.md)
+instead.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,350 @@
+# Developing
+
+These instructions cover setting up stellar-dbt-public locally, running models
+and tests, and the conventions for adding a model.
+
+For what this project is and where its output lives, read the
+[README](README.md). If you plan to open a pull request, also read the
+[contributing guidelines](CONTRIBUTING.md).
+
+## Table of Contents
+
+- [dbt overview](#dbt-overview)
+- [Requirements](#requirements)
+- [Get the code](#get-the-code)
+- [Configure dbt](#configure-dbt)
+- [Project structure](#project-structure)
+- [Running models](#running-models)
+- [Running tests](#running-tests)
+- [Linting](#linting)
+- [Generating the docs site](#generating-the-docs-site)
+- [Continuous integration](#continuous-integration)
+- [Tips and notes](#tips-and-notes)
+
+## dbt overview
+
+dbt transforms data without that data ever leaving the warehouse. When you run
+`dbt run` or `dbt build`, dbt compiles your models to SQL and executes them
+against BigQuery.
+
+- `dbt run` executes the compiled SQL models, without running tests, snapshots,
+  or seeds. See the [`dbt run` reference](https://docs.getdbt.com/reference/commands/run).
+- `dbt build` does everything `dbt run` does, plus tests, snapshots, and seeds.
+  See the [`dbt build` reference](https://docs.getdbt.com/reference/commands/build).
+
+A model is a single `.sql` file containing a final select statement; the
+table or view it produces takes the file's name. Each model's
+[materialization](https://docs.getdbt.com/docs/build/materializations) decides
+how it is persisted. This project uses:
+
+1. [View](https://docs.getdbt.com/docs/build/materializations#view): rebuilt as a view on each run
+2. [Table](https://docs.getdbt.com/docs/build/materializations#table): rebuilt as a table on each run
+3. [Incremental](https://docs.getdbt.com/docs/build/materializations#incremental): inserts or updates records since the last run
+4. [Ephemeral](https://docs.getdbt.com/docs/build/materializations#ephemeral): interpolated into dependent models as a CTE
+5. [Materialized View](https://docs.getdbt.com/docs/build/materializations#materialized-view)
+6. [Incremental Snapshot](macros/materializations/incremental_snapshot.sql): a
+   custom materialization built by SDF to support snapshots with backfilling
+
+> _*Note:*_ If you are new to dbt, start with the
+> [dbt documentation](https://docs.getdbt.com/docs/introduction).
+
+## Requirements
+
+- [Git](https://git-scm.com/downloads)
+- Python and pip. CI runs Python 3.13; verify your install with
+  `python --version` and `pip --version`.
+- The [gcloud CLI](https://cloud.google.com/sdk/docs/install)
+- A GCP project you can create BigQuery datasets in, and a BigQuery quota
+  sufficient for the models you intend to build
+
+Pinned Python dependencies, including `dbt-bigquery` and `sqlfluff`, live in
+[requirements.txt](requirements.txt).
+
+## Get the code
+
+```sh
+git clone https://github.com/stellar/stellar-dbt-public.git
+cd stellar-dbt-public
+```
+
+## Configure dbt
+
+1. Create a `.env` file from the example:
+
+   ```sh
+   cp example.env .env
+   ```
+
+2. Edit the `DBT_*` variables. `profiles.yml` reads all of them from the
+   environment, so dbt fails before running any SQL if one is missing.
+
+   | Variable               | What it sets                                        |
+   | ---------------------- | --------------------------------------------------- |
+   | `DBT_TARGET`           | Target to use: `development`, `test`, or `prod`     |
+   | `DBT_PROJECT`          | GCP project ID that dbt connects to                 |
+   | `DBT_DATASET`          | BigQuery dataset that dbt writes to                 |
+   | `DBT_MAX_BYTES_BILLED` | Ceiling on bytes billed per query                   |
+   | `DBT_JOB_TIMEOUT`      | Seconds dbt waits for a query to complete           |
+   | `DBT_THREADS`          | Models dbt may build concurrently                   |
+   | `DBT_JOB_RETRIES`      | Retries for a failing query                         |
+
+   > _*Important:*_ `example.env` ships with `DBT_TARGET="prod"` and
+   > `DBT_PROJECT="crypto-stellar"`, which are the values production uses. For
+   > local work set `DBT_TARGET="development"` and point `DBT_PROJECT` and
+   > `DBT_DATASET` at **your own** GCP project and a personal dataset. Never run
+   > the `prod` target locally.
+
+   `crypto-stellar` is publicly readable, so you can build against it as a
+   source while writing output to your own project.
+
+3. Run `setup.sh` to create a virtual environment, install the pinned
+   dependencies, install the pre-commit hooks, and run `dbt deps`:
+
+   ```sh
+   source setup.sh
+   ```
+
+   > _*Note:*_ In each new shell you need to reactivate the environment and
+   > reload the variables:
+   >
+   > ```sh
+   > source env/bin/activate
+   > source .env
+   > ```
+
+4. Authenticate to GCP. Local development uses OAuth:
+
+   ```sh
+   gcloud auth login
+   gcloud config set project <your gcp project>
+   gcloud auth application-default login
+   ```
+
+   > _*Note:*_ A GCP service account key also works. See the
+   > [dbt BigQuery setup docs](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#service-account-file).
+
+5. Verify the setup:
+
+   ```sh
+   pip list      # confirms the dependencies installed
+   dbt debug     # confirms the connection and configuration
+   ```
+
+> _*Note:*_ If `dbt debug` fails, check
+> [profiles.yml](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml)
+> and [dbt_project.yml](https://docs.getdbt.com/reference/dbt_project.yml).
+
+## Project structure
+
+The project follows a `staging` → `intermediate` → `marts` approach, with
+`snapshots` for history tracking.
+
+| Layer        | Location               | Default materialization       | Purpose                                          |
+| ------------ | ---------------------- | ----------------------------- | ------------------------------------------------ |
+| Sources      | `models/sources/`      | —                             | Declarations of the raw tables the project reads |
+| Staging      | `models/staging/`      | View                          | Source preprocessing, one model per source table |
+| Intermediate | `models/intermediate/` | Table                         | Joins, aggregations, and business logic          |
+| Marts        | `models/marts/`        | Table                         | Final analytics-ready dimensional models         |
+| Snapshots    | `snapshots/`           | Custom `incremental_snapshot` | SCD Type-2 history with `valid_from` / `valid_to` |
+
+Those are the per-directory defaults set in [dbt_project.yml](dbt_project.yml).
+Individual models override them in their own `config()` block; most marts are
+`incremental` with the `microbatch` strategy rather than full-table rebuilds.
+
+Supporting directories: `macros/` (reusable SQL, including the custom snapshot
+materialization), `tests/` (singular tests, plus generic tests in
+`tests/generic/`), `seeds/` (small CSVs loaded as tables), `models/docs/` (doc
+blocks), and `analyses/`.
+
+### Staging
+
+Receives raw data from the source and prepares it for further transformation.
+
+Do: column selection, renaming columns, casting, flattening structured objects,
+initial filters, and basic cleanup such as replacing empty strings with NULL.
+
+Don't: joins or aggregations.
+
+> _*Note:*_ More on the [staging layer](https://docs.getdbt.com/best-practices/how-we-structure/2-staging).
+
+### Intermediate
+
+Prepares data for the marts. Not every staging model becomes an intermediate
+model.
+
+Do: joins between staging or intermediate models, aggregations or re-graining to
+reach the desired granularity, and complex logic such as business rules or
+metrics.
+
+Don't: ingest raw data, do dimensional modeling, or repeat the staging actions.
+
+> _*Note:*_ More on the [intermediate layer](https://docs.getdbt.com/best-practices/how-we-structure/3-intermediate).
+
+### Marts
+
+Where users access the final dimensional models. Every model is accompanied by a
+`.yml` file of the same name holding descriptions and tests for the model and
+its columns.
+
+Do: organize data into dimension, fact, or aggregate tables; final joins on
+staging and intermediate models; mart-specific tweaks; end user documentation;
+final testing.
+
+Don't: clean data, or repeat the staging and intermediate actions.
+
+> _*Note:*_ More on the [marts layer](https://docs.getdbt.com/best-practices/how-we-structure/4-marts).
+
+### Snapshots
+
+Captures and tracks changes in source data over time, producing SCD Type-2
+tables where each record stores its validity period (`valid_from`, `valid_to`)
+and current state. Snapshots answer point-in-time questions, such as what an
+account's balance was on a given day.
+
+Do: capture historical change in source or staging tables, maintain
+`valid_from` and `valid_to`, use it for entities that need history (accounts,
+balances, contracts), apply deterministic backfills or repairs through Airflow
+orchestration, and build on the custom snapshot macros rather than native dbt
+snapshots so backfills stay possible.
+
+Don't: perform business aggregations or heavy joins — leave those to
+intermediate and marts — store unrelated business logic, or snapshot data that
+does not change, such as static reference tables.
+
+> _*Note:*_ The custom materialization, its macros, orchestration, and repair
+> procedure are documented in [docs/snapshot.md](docs/snapshot.md).
+
+## Running models
+
+Running a dbt model is like running a SQL script. There are several ways to
+select what runs:
+
+```sh
+# The entire project
+dbt <run or build>
+
+# By tag, path, or config
+dbt <run or build> --select tag:tag_1 tag_2 tag_3
+
+# Specific models, and none of their dependencies
+dbt <run or build> --select model_1 model_2 model_3
+
+# A model plus its upstream (+ prefix) and downstream (+ suffix) models
+dbt <run or build> --select +model_1+
+```
+
+> _*Note:*_ dbt also supports `--exclude`, `--defer`, `--target`, and many other
+> selection methods. See the
+> [node selection syntax](https://docs.getdbt.com/reference/node-selection/syntax).
+
+### Batch window variables
+
+Incremental models and several tests are scoped by variables that Airflow sets
+per task and that default to placeholder dates in
+[dbt_project.yml](dbt_project.yml): `batch_start_date`, `batch_end_date`,
+`execution_date`, `snapshot_start_date`, `snapshot_end_date`, and
+`is_singular_airflow_task`.
+
+The defaults are deliberately wide or inert, which means a local run can select
+zero rows and still report success. Pass an explicit window to reproduce what
+production does:
+
+```sh
+dbt run --select my_incremental_model \
+  --vars '{batch_start_date: "2024-06-01", batch_end_date: "2024-06-02"}'
+```
+
+## Running tests
+
+Run tests with `dbt test`, or with `dbt build` to build and test together, using
+the same [node selection syntax](https://docs.getdbt.com/reference/node-selection/syntax)
+as `dbt run`. Both schema and data tests run unless explicitly excluded.
+
+There are three kinds of test:
+
+1. **Singular data tests** — a SQL query in `tests/` that returns failing rows.
+2. **Generic data tests** — parameterized queries applied from a model's `.yml`
+   file. This project defines its own in `tests/generic/`, including
+   `incremental_not_null`, `incremental_unique`,
+   `incremental_unique_combination_of_columns`, `incremental_accepted_values`,
+   `recency`, and `test_expression_is_true`. These are date-scoped variants of
+   the standard tests, so they check only the batch window rather than the whole
+   table.
+3. **Unit tests** — validate model logic against static inputs without
+   materializing the model. This project does not define any yet; they are worth
+   reaching for when a model's logic is intricate enough that a data test would
+   only catch the problem after a full build.
+
+> _*Note:*_ More on [data tests](https://docs.getdbt.com/docs/build/data-tests)
+> and [unit tests](https://docs.getdbt.com/docs/build/unit-tests).
+
+Accepted, already-triaged test failures are recorded in
+`seeds/public_test_exceptions.csv` rather than by disabling the test. Read
+[docs/test_exceptions.md](docs/test_exceptions.md) before adding a row.
+
+## Linting
+
+`setup.sh` installs the pre-commit hooks. Run them over everything before
+opening a pull request:
+
+```sh
+pre-commit run --all-files
+```
+
+The hooks are [sqlfluff](https://docs.sqlfluff.com/) lint and fix, configured by
+[.sqlfluff](.sqlfluff) for the BigQuery dialect and the dbt templater, plus
+`prettier` for JSON and YAML and a handful of hygiene checks.
+
+You can also run sqlfluff directly:
+
+```sh
+sqlfluff lint models/path/to/model.sql
+sqlfluff fix models/path/to/model.sql
+```
+
+> _*Note:*_ The sqlfluff hooks shell out to `pre-commit/for_pre_commit.sh`,
+> which copies `.env` to `.env.tmp` and loads it. A missing or malformed `.env`
+> therefore fails the hook rather than the SQL.
+
+## Generating the docs site
+
+```sh
+dbt docs generate
+dbt docs serve
+```
+
+Merges to `master` regenerate the published docs site and upload it to GCS.
+
+Column descriptions come from two places: the `.yml` co-located with each model,
+and shared doc blocks in `models/docs/` referenced as `{{ doc('column_name') }}`.
+Columns that mean the same thing everywhere belong in
+`models/docs/universal.md`. When you add or change a model, update both the
+co-located `.yml` and any relevant doc block.
+
+## Continuous integration
+
+A pull request runs three checks:
+
+| Check                     | What it does                                                                                    |
+| ------------------------- | ----------------------------------------------------------------------------------------------- |
+| CI Linting                | Runs pre-commit on the changed files, then `diff-quality --violations=sqlfluff --fail-under=95` |
+| dbt project evaluator CI  | Builds the `dbt_project_evaluator` package against `test-hubble-319619`                         |
+| Socket security scan      | Scans dependency changes                                                                        |
+
+The CI Linting job **skips** the sqlfluff pre-commit hooks and relies on
+`diff-quality` instead, which scores only the lines your branch changed and
+fails below 95. So a file with pre-existing violations can pass while your new
+lines fail. Run sqlfluff locally on the files you touched.
+
+## Tips and notes
+
+- `dbt deps` installs packages into `dbt_packages/`, which goes stale as soon as
+  a pin in `packages.yml` moves. Re-run `dbt deps` after pulling, before
+  trusting compiled output or lineage.
+- `dbt --quiet` suppresses the model-by-model output, which can make a run that
+  did nothing look like a run that succeeded. Check the row counts.
+- If a selector matches nothing, dbt exits successfully. Models that come from a
+  package need `fqn:` or `package:` selectors rather than a bare name.
+- The `development` and `test` targets inherit every setting from `prod` in
+  [profiles.yml](profiles.yml) except the project and dataset you supply, so a
+  misconfigured `.env` points a local run straight at production.

--- a/README.md
+++ b/README.md
@@ -1,315 +1,75 @@
 # stellar-dbt-public
 
-Public dbt instance to aid in data transformation for analytics purposes.
-If you're interested in setting up your own dbt project, you can find detailed instructions in the [dbt documentation](https://docs.getdbt.com/docs/introduction).
+A public [dbt](https://docs.getdbt.com/docs/introduction) project that
+transforms Stellar network history into analytics-ready tables in BigQuery.
 
-## Before creating a branch
+It takes the raw ledger, transaction, operation, and state data extracted by
+[stellar-etl](https://github.com/stellar/stellar-etl) and models it into the
+staging, intermediate, mart, and snapshot layers that back
+[Hubble](https://developers.stellar.org/docs/data/analytics/hubble), the
+Stellar Development Foundation's public analytics dataset.
 
-Pay attention, it is very important to know if your modification to this repository is a release (breaking changes), a feature (functionalities) or a patch(to fix bugs). With that information, create your branch name like this:
+## Documentation
 
-- `major/<branch-name>`
-- `minor/<branch-name>`
-- `patch/<branch-name>`
+| Document                                           | Contents                                                                   |
+| -------------------------------------------------- | -------------------------------------------------------------------------- |
+| This README                                        | What the project is and how to consume its output                          |
+| [DEVELOPING.md](DEVELOPING.md)                     | Local setup, running models and tests, project layout, and CI              |
+| [CONTRIBUTING.md](CONTRIBUTING.md)                 | Branch naming, pull request etiquette, release mechanics, and SQL style    |
+| [docs/snapshot.md](docs/snapshot.md)               | The custom snapshot materialization, its macros, and how to repair one     |
+| [docs/test_exceptions.md](docs/test_exceptions.md) | How accepted test failures are recorded                                    |
+| [SECURITY.md](SECURITY.md)                         | Bug bounty scope                                                           |
 
-If branch is already made, just rename it _before passing the pull request_.
+For the Stellar network itself and for guidance on querying the public dataset,
+see the [Stellar developer documentation](https://developers.stellar.org/).
 
-# Table of Contents
+## Querying the data
 
-- [dbt Overview](#dbt-overview)
-  - [Workflow](#workflow)
-  - [dbt Project Structure](#dbt-project-structure)
-    - [Development Folders](#development-folders)
-  - [Tests](#tests)
-- [Getting Started](#getting-started)
-  - [Download the Repo](#download-the-repo)
-  - [Configure dbt](#configure-dbt)
-- [Working with dbt](#working-with-dbt)
-  - [Running Models](#running-models)
-  - [Running Tests](#running-tests)
-- [New Releases](#New-code-release)
+Most people do not need to run this project. The tables it builds are published
+in the public `crypto-stellar` BigQuery project and can be queried directly. See
+the [Hubble documentation](https://developers.stellar.org/docs/data/analytics/hubble)
+for the datasets, access instructions, and cost guidance.
 
-# dbt Overview
+## Project layout
 
-dbt is composed of different moving parts working harmoniously. All of them are important to what dbt does — transforming data. When you execute `dbt run` or `dbt build`, you are running a model that will transform your data without that data ever leaving your warehouse.
+| Layer        | Location               | Purpose                                                  |
+| ------------ | ---------------------- | -------------------------------------------------------- |
+| Sources      | `models/sources/`      | Declarations of the raw tables the project reads         |
+| Staging      | `models/staging/`      | Source preprocessing: selection, renaming, casting       |
+| Intermediate | `models/intermediate/` | Joins, aggregations, and business logic                  |
+| Marts        | `models/marts/`        | Final analytics-ready dimensional models                 |
+| Snapshots    | `snapshots/`           | SCD Type-2 history with `valid_from` / `valid_to`        |
 
-`dbt run` will execute the compiled sql models without running tests, snapshots, nor seeds (if there are any). More information about `dbt run` can be found [here](https://docs.getdbt.com/reference/commands/run)
+`macros/` holds reusable SQL, including the custom `incremental_snapshot`
+materialization. `tests/` holds singular tests and this project's generic
+tests, `seeds/` small CSVs loaded as tables, and `models/docs/` the shared doc
+blocks behind the published column descriptions.
 
-`dbt build` will do everything `dbt run` does plus run tests, snapshots, and seeds (if there are any). More information about `dbt build` can be found [here](https://docs.getdbt.com/reference/commands/build)
+[DEVELOPING.md](DEVELOPING.md#project-structure) describes what belongs in each
+layer.
 
-## Workflow
+## Using this project as a dbt package
 
-The top level of a dbt workflow is the project. A project generally consists of a project configuration `.yml` (in this case the [dbt_project.yml](https://github.com/stellar/stellar-dbt-public/blob/master/dbt_project.yml)) and a directory of the [models](https://github.com/stellar/stellar-dbt-public/tree/master/models). The `dbt_project.yml` tells dbt the project context, and the models let dbt know how to build a specific data set. These models simplify analytics by generating data mart tables.
+This project is published as a dbt package, tagged on every merge to `master`.
+To depend on it, add it to your `packages.yml` pinned to a tag:
 
-A model is a single `.sql` file containing a final select statement for the table or view. The table/view name is the same as the file name. A project can have multiple models where a model can be classified as a staging, intermediate, or mart table/view.
-
-In dbt, you can configure the materialization of your models. Materializations are strategies for persisting dbt models in a warehouse. There are five types of materializations built into dbt. They are:
-
-1. [View](https://docs.getdbt.com/docs/build/materializations#view): your model is rebuilt as a view on each run
-2. [Table](https://docs.getdbt.com/docs/build/materializations#table): your model is rebuilt as a table on each run
-3. [Incremental](https://docs.getdbt.com/docs/build/materializations#incremental): allows dbt to insert or update records into a table since the last time that dbt was run
-4. [Ephemeral](https://docs.getdbt.com/docs/build/materializations#ephemeral): these are not directly built into the database. instead, dbt will interpolate the code from this model into dependent models as a common table expression
-5. [Materialized View](https://docs.getdbt.com/docs/build/materializations#materialized-view): allows the creation and maintenance of materialized views in the target database
-6. [Incremental Snapshot](./macros/materializations/incremental_snapshot.sql): This is a custom materialization built by SDF to support snapshots with backfilling capabilities.
-
-> _*Note:*_ More information about materializations can be found [here](https://docs.getdbt.com/docs/build/materializations#overview)
-
-> _*Note:*_ More information about dbt projects can be found [here](https://docs.getdbt.com/docs/build/projects).
-
-## dbt Project Structure
-
-The stellar-dbt-public project follows a `staging`, `intermediate`, and `marts` approach to modeling.
-
-1. Staging
-   The purpose of the staging layer is to receive the raw data from the source and prepare it for further transformations and analysis.
-
-What to do in staging:
-
-- Column selection
-- Renaming columns
-- Definition of data types (casting columns to String, Numeric...)
-- Flattening of structured objects
-- Initial filters
-- Basic cleanup, like replacing empty strings with NULL, for example
-
-What not to do in staging:
-
-- Joins
-- Aggregations
-
-> _*Note:*_ More information about `staging` layer can be found [here](https://docs.getdbt.com/best-practices/how-we-structure/2-staging).
-
-2. Intermediate
-   In the intermediate layer, the preparation for directing the data to the marts takes place. Not every model in the staging layer will become an intermediate model. This is where it is possible to combine different models to start assembling business rules.
-
-What to do in intermediate:
-
-- Joins between different staging or intermediate models
-- Aggregations or re-graining to fan out or collapse columns to the desired granularity
-- Complex logic such as the integration of business logic, rules, or metrics
-
-What not to do in intermediate:
-
-- Ingestion of raw data
-- Dimensional modeling (creation of fact, dimension, or aggregate tables)
-- The actions listed in staging
-
-> _*Note:*_ More information about `intermediate` layer can be found [here](https://docs.getdbt.com/best-practices/how-we-structure/3-intermediate).
-
-3. Marts
-   The marts layer is where users can access final dimensional modeling tables. Each model will be accompanied by a `.yml` file with the same name. The `.yml` file contains the descriptions and tests for the model and its columns.
-
-What to do in marts:
-
-- Organization of data into dimension, fact, or aggregate tables
-- Mart-specific tweaks
-- Final joins for staging and intermediate models
-- End user documentation
-- Final testing
-
-What not to do in marts:
-
-- Data cleaning
-- The actions listed in staging or intermediate
-
-> _*Note:*_ More information about `marts` layer can be found [here](https://docs.getdbt.com/best-practices/how-we-structure/4-marts).
-
-
-4. Snapshots
-   The snapshots layer is used to capture and track changes in source data over time. It allows us to build Slowly Changing Dimension (SCD) Type-2 tables, where each record stores both its validity period (valid_from, valid_to) and current state. Snapshots enable analysts to answer point-in-time questions (e.g., “What was a user’s balance on March 30, 2024?”).
-
-What to do in snapshots:
-
-- Capture historical changes in source or staging tables
-- Maintain valid_from and valid_to fields for tracking record validity
-- Use for entities that require historical tracking (users, balances, contracts, etc.)
-- Apply deterministic backfills or repairs using Airflow orchestration
-- Build on top of custom snapshot macros (instead of DBT native snapshots) for reliability and backfilling capabilites.
-
-What not to do in snapshots:
-
-- Perform business aggregations or heavy joins (leave this to intermediate/marts)
-- Store unrelated business logic — snapshots should focus only on state tracking
-- Use for data that does not require historical changes (e.g., static reference tables)
-
-> _*Note:*_ More information about `snapshot` in this project (custom materialization, macros, orchestration, and repairs) can be found in [here](./docs/snapshot.md)
-
-### Development Folders
-
-| Name         | Description                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------- |
-| Source       | Stores the raw data that will be used as inputs for the dbt transformations.                  |
-| Staging      | Stages the pre-processed or cleaned data before performing the transformations.               |
-| Intermediate | Contains the transformed and processed data.                                                  |
-| Marts        | Houses the final data models or data marts, which are the end results of the dbt project.     |
-| Docs         | Stores documentation related to your dbt project.                                             |
-| Macros       | Contains reusable SQL code snippets known as macros.                                          |
-| Tests        | Contains defining tests to validate the accuracy and correctness of the data transformations. |
-
-## Tests
-
-Tests are assertions made about models and other resources in the dbt project. When you run `dbt test` or `dbt build`, dbt will tell you if each test in your project passes or fails.
-
-There are three different test types:
-
-1. Singular data tests: a SQL query that returns failing rows
-2. Generic data tests: is a parameterized query that accepts arguments. The test query is defined in a special test block (like a macro)
-3. Unit tests: validates SQL modeling logic on a small set of static inputs before materializing the full model
-
-> _*Note:*_ More information about `data tests` can be found [here](https://docs.getdbt.com/docs/build/data-tests)
-
-> _*Note:*_ More information about `unit tests` can be found [here](https://docs.getdbt.com/docs/build/unit-tests)
-
-<br>
-
-
-# Getting Started
-
-## Download gcloud CLI
-Follow the instructions here: https://cloud.google.com/sdk/docs/install
-
-## Verify python and pip installation
-1. Run
-```
-python --version
-pip --version
-```
-to make sure python and pip are installed.
-
-## Download the Repo
-
-Clone the git repository locally
-
-```
-git clone https://github.com/stellar/stellar-dbt-public.git
+```yaml
+packages:
+  - git: "https://github.com/stellar/stellar-dbt-public.git"
+    revision: <tag>
 ```
 
-## Configure dbt
+Then run `dbt deps`. Because the pin is by tag, a release here reaches your
+project only once you bump that revision.
 
-1. Create a new `.env` file by copying `example.env`
+## Contributing
 
-```
-cp example.env .env
-```
-
-2. Set the various `DBT_*` variables (e.g. `DBT_DATASET`, `DBT_PROJECT`)
-
-```
-export DBT_TARGET="prod";
-
-export DBT_DATASET="crypto_stellar";
-
-export DBT_PROJECT="crypto-stellar";
-
-export DBT_MAX_BYTES_BILLED="550000000000";
-
-export DBT_JOB_TIMEOUT="300";
-
-export DBT_THREADS="1";
-
-export DBT_JOB_RETRIES="1";
-```
-3. Execute `setup.sh` to create a virtual environment and install required dbt dependencies
-
-```
-source setup.sh
-```
-> _*Note:*_ Once the virtualenv is created, you will have to run
-```
-source env/bin/activate
-```
-to activate the virtual environment.
-
-
-> _*Note:*_ Once this command will set up a virtualenv, everytime you restart the bash command/or the virtual environment, you will have to run
-```
-source .env
-```
-to load the environment variables.
-
-4. Set up OAuth by running `gcloud init` and following the account information prompts
-
-> _*Note:*_ You only need OAuth for local development
-
-> _*Note:*_ It is also possible to use a GCP service account key. Instructions [here](https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#service-account-file)
-
-> _*Note:*_ If using the GCS datastore, you can run the following to set GCP credentials to use in your shell
-
-```
-gcloud auth login
-gcloud config set project <your gcp project>
-gcloud auth application-default login
-```
-
-5. To verify if all libraries have been correctly installed, use the command `pip list`
-6. Execute the command `dbt debug` to ensure that all configurations are working correctly
-
-> _*Note:*_ You can find instructions to install the `GCP CLI` [here](https://cloud.google.com/sdk/docs/install)
-
-> _*Note:*_ More information about `dbt core` setup can be found [here](https://docs.getdbt.com/docs/core/about-core-setup)
-
-> _*Note:*_ You may need to modify `profiles.yml` and `dbt_project.yml` if any of the above commands fail
-> <br> [profiles.yml docs](https://docs.getdbt.com/docs/core/connect-data-platform/profiles.yml) > <br> [dbt_project.yml docs](https://docs.getdbt.com/reference/dbt_project.yml)
-
-<br>
+Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) for branch
+naming, pull request expectations, and release mechanics, and
+[DEVELOPING.md](DEVELOPING.md) to get a local environment running.
 
 ---
 
-# Working with dbt
-
-## Running Models
-
-Executing a dbt model is the same as executing a SQL script. There are many ways to run dbt models:
-
-1. Run the entire project with
-
-```
-dbt <run or build>
-```
-
-2. Run tagged models, paths, or configs with
-
-```
-dbt <run or build> --select tag:tag_1 tag_2 tag_3
-```
-
-3. Run specific models with
-
-```
-dbt <run or build> --select model_1 model_2 model_3
-```
-
-> _*Note:*_ this runs only the specified models and none of its dependencies
-
-4. Run the model with its downstream and/or upstream models by adding a `+` to the beginning (downstream) and/or the end (upstream) of the model name
-
-```
-dbt <run or build> --select +model_1+
-```
-
-> _*Note:*_ dbt supports `--excluding`, `--defer`, `--target`, and many other selection types. Please refer to the [node selection syntax documentation](https://docs.getdbt.com/reference/node-selection/syntax).
-
-## Running Tests
-
-Execute tests with the commands `dbt test` or `dbt build` with the desired [node selection syntax](https://docs.getdbt.com/reference/node-selection/syntax). This will run schema, data, and unit tests unless they are explicitly excluded. More information about tests can be found [here](https://docs.getdbt.com/reference/commands/test).
-
-# New Releases
-
-In order to enable other repositories to work with and build on top of this dbt repo, it was configured as a package. Due to this, commiting to the repository requires a few extra steps to ensure git tagging is consistent, so that changes will not break any code downstream. When commiting changes, there are 3 main version changes that can be applied to the repository, as follows:
-
-| Change | Description                                                                |
-| ------ | -------------------------------------------------------------------------- |
-| Major  | Version when making incompatible changes                                   |
-| Minor  | Version change when adding functionalities in a backward compatible manner |
-| Patch  | Version change when making backward compatible bug fixes                   |
-
-In order to apply git tagging properly, the last commit message from a repo must contain a hashtag(#) followed by the change type present in that commit. This will allow github to detect the type of change being pushed and increment the version accordingly. For example:
-
-`'Fix trade-agg bug #patch'`
-
-# Futher Development
-
-TODO
-
----
-
-> **Note:** This repository is not in scope for the Stellar Development Foundation bug bounty program. Vulnerabilities found in this repo are not eligible for rewards.
+> **Note:** This repository is not in scope for the Stellar Development
+> Foundation bug bounty program. Vulnerabilities found in this repo are not
+> eligible for rewards.


### PR DESCRIPTION
### What

Splits the README into three documents, following the structure requested in
stellar/hubble#412:

- **`DEVELOPING.md`** (new) — dbt overview, requirements, getting the code,
  configuring dbt, project structure and what belongs in each layer, running
  models, batch window variables, running tests, linting, generating the docs
  site, CI checks, and tips.
- **`CONTRIBUTING.md`** (new) — branches, commit messages, pull request
  etiquette, issues, release mechanics, SQL style, model conventions,
  documentation, and security.
- **`README.md`** (rewritten as an index) — what the project is, how to query
  the published data without running anything, the project layout, how to
  consume it as a dbt package, and a Documentation table pointing at every
  other doc including `docs/snapshot.md` and `docs/test_exceptions.md`.

### Why

The README was 315 lines covering a dbt tutorial, local setup, layer
guidance, and release mechanics at once. Most people who land on this repo just
want to query the public dataset and never run dbt at all; contributors want
setup instructions. Splitting by audience gets each of them there faster, which
is what the issue asks for.

Two things were fixed rather than copied forward while moving content:

- **Releases.** The README said the last commit message must contain
  `#patch`/`#minor`/`#major`. `.github/workflows/release.yml` does not read
  commit messages — it reads the **branch prefix**, and anything unrecognized
  falls through to a patch bump. Following the old instruction on an
  unprefixed branch would ship a breaking change as a patch. `CONTRIBUTING.md`
  documents what the workflow actually does.
- **Local setup pointing at production.** The README's configure step told you
  to set `DBT_TARGET="prod"` and `DBT_PROJECT="crypto-stellar"` — the values
  `example.env` ships with, which are production's. `DEVELOPING.md` now says to
  use the `development` target against your own project and dataset, and notes
  that `crypto-stellar` stays readable as a source. (Fixing `example.env`
  itself is a separate change; this PR only documents it.)

Also corrected against the code while writing: intermediate models default to
`table`, not view; the project's generic tests live in `tests/generic/`; and
`CI Linting` skips the sqlfluff pre-commit hooks and gates on `diff-quality
--fail-under=95` over changed lines only, which is why a file with
pre-existing violations can pass while new lines fail.

### Known limitations

Docs only — no models, tests, or macros touched. `example.env` still ships the
production values.

stellar/hubble#412 also asks for these files in `stellar-etl-airflow` and
`stellar-dbt`, which are internal repos, so they are out of scope here. The
companion public-repo PR is stellar/stellar-etl#475.
