### PR TITLE
Update PR and Issue templates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -143,3 +143,18 @@ Hooks:
    - Model tags must be from the approved allowlist (see `.pre-commit-config.yaml`)
    - All source columns/tables must have descriptions
 3. **Prettier** — formats `.json`/`.yaml`/`.yml` files
+
+## Pull requests
+
+Write the PR body as a cover note for a reviewer, not a changelog or a file-by-file summary.
+Use the smallest shape that makes the change easier to review:
+
+- Small or obvious change: one paragraph, no headings.
+- Model, macro, or test change: what changed and its effect. Add root cause or the non-obvious approach only when the diff does not already show it.
+- Schema, grain, tag, or source change: name the affected model and column, and the full refresh or backfill needed on merge.
+- Snapshot change: say whether a rebuild is needed and over what `snapshot_start_date` window.
+- Anything stellar-dbt consumes: say in Data impact that it needs a `packages.yml` pin bump, and link the companion PR if it exists.
+
+IMPORTANT: do not add Summary, Changes, Test Plan, or Files Changed sections. Do not paste commands, dbt run or test output, CI logs, commit logs, or file lists. No emoji. No step-by-step narration of what you did.
+
+Fill the headings in `.github/pull_request_template.md` and no others. Treat the HTML comments in that template as instructions: follow them, then delete them from the final body. Leave the footer checkboxes unticked; they are the author's to tick.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: A model, table, snapshot, or test is producing wrong or missing data
+labels: ["bug"]
+body:
+  - type: input
+    id: affected
+    attributes:
+      label: Affected model, table, or tag
+      description: The dbt model, BigQuery table, or dbt tag where the problem shows up.
+      placeholder: crypto_stellar_dbt.enriched_history_operations, or tag:current_state
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: What you expected vs. what you got
+      placeholder: |
+        Expected: one row per (account_id, closed_at day) in accounts_current
+        Actual: 2026-09-03 has ~40 duplicate account_ids
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Query or command that shows it
+      description: A query, a dbt selector, or the failing test. Leave blank if you do not have one yet.
+      render: sql
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Impact
+      options:
+        - Blocking a stakeholder
+        - Wrong data in production
+        - Internal only
+        - Cosmetic
+    validations:
+      required: true
+
+  - type: input
+    id: started
+    attributes:
+      label: When it started
+      description: A date, a dbt run, or a release, if you know it.
+      placeholder: first seen after the v20260908 release
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: A new model, a change to an existing one, a new test, or tooling work
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Kind
+      options:
+        - New model
+        - Change to an existing model
+        - New or changed snapshot
+        - New test or data quality check
+        - Tooling or CI
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve
+      description: The question someone cannot answer today, or the failure this would have caught.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to see
+      description: The grain, the columns, or the behavior you want. A rough shape is fine.
+    validations:
+      required: true
+
+  - type: input
+    id: affected
+    attributes:
+      label: Affected models or tables
+      placeholder: int_trades_enriched, history_trades
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,36 +1,15 @@
-<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
-template and use a short description, but in your description aim to include both what the
-change is, and why it is being made, with enough context for anyone to understand. -->
+## What & why
 
-<details>
-  <summary>PR Checklist</summary>
+## Data impact
+<!-- Models, tables, or tags affected. Full refresh or backfill needed on merge?
+     Does stellar-dbt need a `packages.yml` pin bump to pick this up?
+     "None" is a valid answer. -->
 
-### PR Structure
+## What feedback do you want
+<!-- e.g. "check the incremental logic", "sanity-check the grain", "rubber stamp" -->
 
-- [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
-- [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
-      otherwise).
-- [ ] This PR's title starts with the jira ticket associated with the PR.
+---
 
-### Thoroughness
-
-- [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
-- [ ] I've updated the docs and README with the added features, breaking changes, new instructions on how to use the repository.
-
-### Release planning
-
-- [ ] I've decided if this PR requires a new major/minor/patch version accordingly to
-    [semver](https://semver.org/), and I've changed the name of the BRANCH to major/* , minor/* or patch/* .
-</details>
-
-### What
-
-[TODO: Short statement about what is changing.]
-
-### Why
-
-[TODO: Why this change is being made. Include any context required to understand the why.]
-
-### Known limitations
-
-[TODO or N/A]
+- [ ] I ran this and reviewed the diff myself.
+- [ ] Descriptions live in doc blocks under `models/docs/`, and I read every block I referenced.
+- [ ] Branch is named `major/*`, `minor/*`, or `patch/*` (release-drafter reads it).


### PR DESCRIPTION
## What & why

Claude writes bloated PR bodies in these repos: Summary / Changes / Test Plan headings, pasted output, file-by-file lists. The fix is structural rather than adverbial, because GitHub documents style instructions ("be concise", "answer with a certain level of detail") as among the least reliable custom instructions you can give a model. This works three layers at once:

- **A thin PR template** with nothing left to pad: three headings and three checkboxes.
- **A size ladder and an explicit deny-list in `.claude/CLAUDE.md`**, the layer that actually changes behavior. Claude Code reads CLAUDE.md every session and does not reliably read `.github/pull_request_template.md`.
- **YAML issue forms**, the only server-side enforcement GitHub offers. There is no `validations: required` equivalent for PRs.

`What feedback do you want` is the one genuinely new heading. MSR 2026 (80k PRs, 156 projects) found requesting specific feedback is the single strongest predictor of merge, present in 16% of PRs, and ranked *least* important by the developers it surveyed. Nobody adds it voluntarily, so it goes in the skeleton.

Mirrors stellar/stellar-dbt#1146. The CLAUDE.md ladder is tailored per repo; here it names the `packages.yml` pin bump in stellar-dbt, since merging here does not ship the change internally. Issue forms replace the `stellar/.github` fallback, which asks contributors for `stellar version` output.

## Data impact

None. Templates, agent instructions, and issue forms only. No models, no tables, no refresh.

## What feedback do you want

Whether dropping five checklist items loses anything you rely on: jira-ticket titles (dead, no recent PR uses one), "adds tests", "narrow scope", "no mixed refactoring" (all now in the CLAUDE.md rules, where they shape the body instead of being an unticked box), and "updated docs". The doc-block rule survives as a footer checkbox because it is repo-specific and load-bearing.

No `config.yml` here, deliberately: this repo is public, so it keeps the org's Discord and Stack Exchange contact links.

---

- [ ] I ran this and reviewed the diff myself.
- [ ] Descriptions live in doc blocks under `models/docs/`, and I read every block I referenced.
- [ ] Branch is named `major/*`, `minor/*`, or `patch/*` (release-drafter reads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
