### PR TITLE
patch: give the Claude workflow full git history (fetch-depth: 0)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -82,7 +82,16 @@ jobs:
         with:
           repository: ${{ steps.checkout-target.outputs.repository || github.repository }}
           ref: ${{ steps.checkout-target.outputs.ref || github.ref }}
-          fetch-depth: 1
+          # Full history. The agent routinely has to decide whether a ticket is
+          # already done, and a depth-1 checkout leaves it with no `git log`,
+          # `git blame` or `git log -S` to answer that with. It then infers
+          # history from HEAD and gets it wrong: on stellar-dbt#1101 it
+          # correctly found the models already present, but attributed them to
+          # the commit at HEAD -- which touched only this workflow file --
+          # implying a repo-hygiene problem that did not exist. A wrong
+          # justification for a right answer is harder to catch than a wrong
+          # answer, so pay the clone cost and give it real history.
+          fetch-depth: 0
 
       - name: Exchange GitHub OIDC token for Anthropic access token
         id: anthropic-auth


### PR DESCRIPTION
## What

`.github/workflows/claude.yml` checks the repo out with `fetch-depth: 1`. This changes it to `fetch-depth: 0` so the agent gets real git history.

## Why

From the issue-automation evaluation run on 2026-09-10/11, which tagged `@claude` on every open non-epic issue across all six data-platform repos (372 issues).

A large share of what the agent is asked to do is decide **whether a ticket is already done** — that turned out to be 94 of the 372 issues, a quarter of the backlog. Answering it properly needs `git log`, `git blame`, or `git log -S`. With `fetch-depth: 1` the checkout is a single commit, so none of those work, and the agent falls back to inferring history from `HEAD`.

The concrete failure, on stellar-dbt#1101:

> *"It landed inside commit `f6a4fbe0` — whose message ('Give the Claude Code workflow write access to push its work') is unrelated to its contents, which is presumably why this got filed as still-open."*

`f6a4fbe0` touches exactly one file, `.github/workflows/claude.yml`. The models it was talking about landed in `d531ec65` ("Release v20260908"). The agent reached the **right conclusion** — the work really was already on `master` — via **invented evidence**, and that invented evidence implied a repo-hygiene problem (a release commit with a misleading message) that does not exist.

A wrong justification attached to a right answer is harder to catch than a wrong answer, because the conclusion checks out and nobody re-reads the reasoning.

Agents also flagged the shallow clone themselves, unprompted — on stellar-dbt#964:

> *"this checkout is a shallow clone (depth 1) and `git fetch --unshallow` required interactive approval that wasn't available in this run, so I couldn't confirm when the jenkins→ci rename and CLAUDE.md cleanup actually landed."*

## Cost

A full-history clone instead of a single commit. This job already runs an LLM agent for minutes at a time, so the extra clone time is not the constraint. If it ever becomes one on the larger repos, `fetch-depth: 0` can be swapped for a bounded depth — but a bounded depth reintroduces the same class of error at the boundary, so full history is the honest default.

## Testing

- `yq` parses the workflow and resolves `fetch-depth` to `0`.
- No other key changed; the diff is the one value plus an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)